### PR TITLE
gg20 key generation API. This hopefully gives a good example about how this can be used.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ reqwest = { version = "0.9", default-features = false }
 uuid = { version = "0.8", features = ["v4"] }
 serde_json = "1.0"
 libsecp256k1 = "0.3.2"
+rand = "0.7"
 
 [patch.crates-io]
 rust-gmp = { version = "0.5.0", features = ["serde_support"], git = "https://github.com/KZen-networks/rust-gmp" }

--- a/src/protocols/multi_party_ecdsa/gg_2020/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/test.rs
@@ -46,6 +46,11 @@ fn test_keygen_t1_n2() {
 }
 
 #[test]
+fn test_keygen_2_12() {
+    assert!(keygen_t_n_parties(2, 12).is_ok());
+}
+
+#[test]
 fn test_keygen_t2_n3() {
     assert!(keygen_t_n_parties(2, 3).is_ok());
 }
@@ -75,10 +80,10 @@ fn test_keygen_orchestration() {
     let mut rng = rand::thread_rng();
     let mut share_count_test: u16;
     let mut threshold_test: u16;
-    for _count in 0..2 {
+    for _count in 0..5 {
         loop {
             share_count_test = rng.gen::<u16>() % 16;
-            if share_count_test < 2 {
+            if share_count_test < 3 {
                 continue;
             } else {
                 break;

--- a/src/protocols/multi_party_ecdsa/gg_2020/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/test.rs
@@ -46,11 +46,6 @@ fn test_keygen_t1_n2() {
 }
 
 #[test]
-fn test_keygen_2_12() {
-    assert!(keygen_t_n_parties(2, 12).is_ok());
-}
-
-#[test]
 fn test_keygen_t2_n3() {
     assert!(keygen_t_n_parties(2, 3).is_ok());
 }


### PR DESCRIPTION
The current unit test keygen_t_n_parties function does test the full process but it does not break the whole implementation into stages that are usable as an API. 

This test is a sample for that. Hopefully this is self documenting and can help people who are trying to use this project.

I will follow up with a similar PR for signing.

I am also thinking if a json in/json out interface could be setup for these stages to help demonstrate it in much more readable request-json/response-json like log. @omershlo 