### PR TITLE
add some documentation for signing non-textual messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ run `gg18_keygen_client` as follows: `./gg18_keygen_client http://127.0.0.1:8001
 
 Run `./gg18_sign_client`. The application should be in the same folder as the `keys.store` file (or custom filename generated in keygen). the application takes three arguments: `IP:port` as in keygen, `filename` and message to be signed: `./gg18_sign_client http://127.0.0.1:8001 keys.store "KZen Networks"`. The same message should be used by all signers. Once `t+1` parties join the protocol will run and will output to screen signatue (R,s).
 
+The `./gg18_sign_client` executable initially tries to unhex its input message (the third parameter). Before running ensure two things:
+
+1. If you want to pass a binary message to be signed - hex it.
+2. If you want to pass a textual message in a non-hex form, make sure it can't be unhexed.
+Simply put, the safest way to use the signing binary is to just always hex your messages before passing them to the `./gg18_sign_client` executable.
+
+#### Example
+To sign the message `hello world`, first calculate its hexadecimal representation. This yields the `68656c6c6f20776f726c64`.
+Then, run:
+```bash
+./gg18_sign_client http://127.0.0.1:8001 keys.store "68656c6c6f20776f726c64"
+```
+
 ### GG18 demo
 
 Run `./run.sh` (located in `/demo` folder) in the main folder. Move `params` file to the same folder as the excutables (usually `/target/release/examples`). The script will spawn a shared state machine, clients in the number of parties and signing requests for the `threshold + 1` first parties.


### PR DESCRIPTION
Due to some misunderstandings just added some lines to the README on how to properly sign with the demo some non-textual messages.