### PR TITLE
Second dlog proof between h1 and h2 added

### DIFF
--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/keygen/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/keygen/rounds.rs
@@ -260,7 +260,7 @@ impl Round4 {
         let h1_h2_n_tilde_vec = self
             .bc_vec
             .iter()
-            .map(|bc1| bc1.dlog_statement.clone())
+            .map(|bc1| bc1.dlog_statement_base_h1.clone())
             .collect::<Vec<DLogStatement>>();
 
         let (head, tail) = self.y_vec.split_at(1);

--- a/src/protocols/multi_party_ecdsa/gg_2020/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/test.rs
@@ -181,7 +181,7 @@ fn keygen_t_n_parties(
         .collect::<Vec<EncryptionKey>>();
     let h1_h2_N_tilde_vec = bc1_vec
         .iter()
-        .map(|bc1| bc1.dlog_statement.clone())
+        .map(|bc1| bc1.dlog_statement_base_h1.clone())
         .collect::<Vec<DLogStatement>>();
     let y_vec = (0..n).map(|i| decom_vec[i].y_i).collect::<Vec<GE>>();
     let mut y_vec_iter = y_vec.iter();


### PR DESCRIPTION
This PR adds a check that makes sure that parameters `h1` and `h2` from `Keys` structure generate the same group. @omershlo 