### PR TITLE
`pk` from `DLogProof` from keygen's Round4 is now verified against VSS.

### DIFF
--- a/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
@@ -392,18 +392,21 @@ impl Keys {
         comm * &li
     }
 
-    pub fn verify_dlog_proofs(
+    pub fn verify_dlog_proofs_check_against_vss(
         params: &Parameters,
         dlog_proofs_vec: &[DLogProof<GE>],
         y_vec: &[GE],
+        vss_vec: &[VerifiableSS<GE>],
     ) -> Result<(), ErrorType> {
         let mut bad_actors_vec = Vec::new();
         assert_eq!(y_vec.len() as u16, params.share_count);
         assert_eq!(dlog_proofs_vec.len() as u16, params.share_count);
+        let xi_commitments = Keys::get_commitments_to_xi(vss_vec);
         let xi_dlog_verify = (0..y_vec.len())
             .map(|i| {
                 let ver_res = DLogProof::verify(&dlog_proofs_vec[i]).is_ok();
-                if ver_res == false {
+                let verify_against_vss = xi_commitments[i] == dlog_proofs_vec[i].pk;
+                if !ver_res || !verify_against_vss {
                     bad_actors_vec.push(i);
                     false
                 } else {

--- a/src/protocols/multi_party_ecdsa/gg_2020/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/test.rs
@@ -243,7 +243,12 @@ fn keygen_t_n_parties(
 
     let pk_vec = (0..n).map(|i| dlog_proof_vec[i].pk).collect::<Vec<GE>>();
 
-    let dlog_verification = Keys::verify_dlog_proofs(&params, &dlog_proof_vec, &y_vec);
+    let dlog_verification = Keys::verify_dlog_proofs_check_against_vss(
+        &params,
+        &dlog_proof_vec,
+        &y_vec,
+        &vss_scheme_vec,
+    );
 
     if dlog_verification.is_err() {
         return Err(dlog_verification.err().unwrap());


### PR DESCRIPTION
In `party_i.rs` `verify_dlog_proofs` method changed so it could also check if `pk` from the proofs are consistent with VSS. Keygen's `rounds.rs` changed accordingly.