### PR TITLE
Replace with pure rust implementation of libsecp256k1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cclst = ["class_group"]
 subtle = { version = "2" }
 serde = { version = "1.0", features = ["derive"] }
 zeroize = "1"
-libsecp256k1 = "0.3.2"
+secp256k1 = { package = "libsecp256k1", git = "https://github.com/paritytech/libsecp256k1.git" }
 curv = { package = "curv-kzen", version = "0.7", default-features = false }
 round-based = { version = "0.1.4", features = [] }
 thiserror = "1.0.23"

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -214,7 +214,7 @@ pub fn check_sig(r: &FE, s: &FE, msg: &BigInt, pk: &GE) {
     compact.extend(vec![0u8; 32 - bytes_s.len()]);
     compact.extend(bytes_s.iter());
 
-    let secp_sig = Signature::parse_slice(compact.as_slice()).unwrap();
+    let secp_sig = Signature::parse_standard_slice(compact.as_slice()).unwrap();
 
     let is_correct = verify(&msg, &secp_sig, &pk);
     assert!(is_correct);

--- a/src/protocols/multi_party_ecdsa/gg_2018/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2018/test.rs
@@ -408,7 +408,7 @@ fn check_sig(r: &FE, s: &FE, msg: &BigInt, pk: &GE) {
     compact.extend(vec![0u8; 32 - bytes_s.len()]);
     compact.extend(bytes_s.iter());
 
-    let secp_sig = Signature::parse_slice(compact.as_slice()).unwrap();
+    let secp_sig = Signature::parse_standard_slice(compact.as_slice()).unwrap();
 
     let is_correct = verify(&msg, &secp_sig, &pk);
     assert!(is_correct);

--- a/src/protocols/multi_party_ecdsa/gg_2020/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/test.rs
@@ -718,7 +718,7 @@ pub fn check_sig(r: &FE, s: &FE, msg: &BigInt, pk: &GE) {
     compact.extend(vec![0u8; 32 - bytes_s.len()]);
     compact.extend(bytes_s.iter());
 
-    let secp_sig = Signature::parse_slice(compact.as_slice()).unwrap();
+    let secp_sig = Signature::parse_standard_slice(compact.as_slice()).unwrap();
 
     let is_correct = verify(&msg, &secp_sig, &pk);
     assert!(is_correct);


### PR DESCRIPTION
PR replaces the secp256k1 with paritytech's libsecp256k1 which is a pure rust implementation. 