### PR TITLE
Range proofs and moduli sizes checks added

### DIFF
--- a/examples/gg18_sign_client.rs
+++ b/examples/gg18_sign_client.rs
@@ -108,7 +108,7 @@ fn main() {
     let xi_com_vec = Keys::get_commitments_to_xi(&vss_scheme_vec);
     //////////////////////////////////////////////////////////////////////////////
     let (com, decommit) = sign_keys.phase1_broadcast();
-    let (m_a_k, _) = MessageA::a(&sign_keys.k_i, &party_keys.ek);
+    let (m_a_k, _) = MessageA::a(&sign_keys.k_i, &party_keys.ek, &[]);
     assert!(broadcast(
         &client,
         party_num_int,
@@ -159,12 +159,16 @@ fn main() {
                 &sign_keys.gamma_i,
                 &paillier_key_vector[signers_vec[(i - 1) as usize]],
                 m_a_vec[j].clone(),
-            );
+                &[],
+            )
+            .unwrap();
             let (m_b_w, beta_wi, _, _) = MessageB::b(
                 &sign_keys.w_i,
                 &paillier_key_vector[signers_vec[(i - 1) as usize]],
                 m_a_vec[j].clone(),
-            );
+                &[],
+            )
+            .unwrap();
             m_b_gamma_send_vec.push(m_b_gamma);
             m_b_w_send_vec.push(m_b_w);
             beta_vec.push(beta_gamma);

--- a/src/protocols/multi_party_ecdsa/gg_2018/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2018/test.rs
@@ -175,10 +175,11 @@ fn sign(t: u16, n: u16, ttag: u16, s: Vec<usize>) {
 
     // each party i sends encryption of k_i under her Paillier key
     // m_a_vec = [ma_0;ma_1;,...]
+    // range proofs are ignored here, as there's no h1, h2, N_tilde setup in this version of GG18
     let m_a_vec: Vec<_> = sign_keys_vec
         .iter()
         .enumerate()
-        .map(|(i, k)| MessageA::a(&k.k_i, &party_keys_vec[s[i]].ek).0)
+        .map(|(i, k)| MessageA::a(&k.k_i, &party_keys_vec[s[i]].ek, &[]).0)
         .collect();
 
     // each party i sends responses to m_a_vec she received (one response with input gamma_i and one with w_i)
@@ -203,9 +204,16 @@ fn sign(t: u16, n: u16, ttag: u16, s: Vec<usize>) {
                 &key.gamma_i,
                 &party_keys_vec[s[ind]].ek,
                 m_a_vec[ind].clone(),
-            );
-            let (m_b_w, beta_wi, _, _) =
-                MessageB::b(&key.w_i, &party_keys_vec[s[ind]].ek, m_a_vec[ind].clone());
+                &[],
+            )
+            .unwrap();
+            let (m_b_w, beta_wi, _, _) = MessageB::b(
+                &key.w_i,
+                &party_keys_vec[s[ind]].ek,
+                m_a_vec[ind].clone(),
+                &[],
+            )
+            .unwrap();
 
             m_b_gamma_vec.push(m_b_gamma);
             beta_vec.push(beta_gamma);

--- a/src/protocols/multi_party_ecdsa/gg_2020/blame.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/blame.rs
@@ -131,6 +131,7 @@ impl GlobalStatePhase5 {
                     &self.k_vec[i],
                     &self.encryption_key_vec[i],
                     &self.k_randomness_vec[i],
+                    &[],
                 );
 
                 // check message a
@@ -138,27 +139,33 @@ impl GlobalStatePhase5 {
                     bad_signers_vec.push(i)
                 }
 
-                let alpha_beta_vector = (0..len - 1)
-                    .map(|j| {
-                        let ind = if j < i { j } else { j + 1 };
-                        let (message_b, beta) = MessageB::b_with_predefined_randomness(
-                            &self.gamma_vec[ind],
-                            &self.encryption_key_vec[i],
-                            self.m_a_vec[i].clone(),
-                            &self.beta_randomness_vec[i][j],
-                            &self.beta_tag_vec[i][j],
-                        );
-                        // check message_b
-                        if message_b.c != self.m_b_mat[i][j].c {
-                            bad_signers_vec.push(ind)
-                        }
+                let alpha_beta_vector = if bad_signers_vec.is_empty() {
+                    (0..len - 1)
+                        .map(|j| {
+                            let ind = if j < i { j } else { j + 1 };
+                            let (message_b, beta) = MessageB::b_with_predefined_randomness(
+                                &self.gamma_vec[ind],
+                                &self.encryption_key_vec[i],
+                                message_a.clone(),
+                                &self.beta_randomness_vec[i][j],
+                                &self.beta_tag_vec[i][j],
+                                &[],
+                            )
+                            .unwrap();
+                            // check message_b
+                            if message_b.c != self.m_b_mat[i][j].c {
+                                bad_signers_vec.push(ind)
+                            }
 
-                        let k_i_gamma_j = self.k_vec[i] * self.gamma_vec[ind];
-                        let alpha = k_i_gamma_j.sub(&beta.get_element());
+                            let k_i_gamma_j = self.k_vec[i] * self.gamma_vec[ind];
+                            let alpha = k_i_gamma_j.sub(&beta.get_element());
 
-                        (alpha, beta)
-                    })
-                    .collect::<Vec<(FE, FE)>>();
+                            (alpha, beta)
+                        })
+                        .collect::<Vec<(FE, FE)>>()
+                } else {
+                    vec![]
+                };
 
                 alpha_beta_vector
             })
@@ -333,6 +340,7 @@ impl GlobalStatePhase6 {
                 &self.k_vec[i],
                 &self.encryption_key_vec[i],
                 &self.k_randomness_vec[i],
+                &[],
             )
             .c != self.m_a_vec[i].c
             {

--- a/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
@@ -46,6 +46,8 @@ use crate::utilities::zk_pdl_with_slack::{PDLwSlackProof, PDLwSlackStatement, PD
 use curv::cryptographic_primitives::proofs::sigma_valid_pedersen::PedersenProof;
 
 const SECURITY: usize = 256;
+const PAILLIER_MIN_BIT_LENGTH: usize = 2047;
+const PAILLIER_MAX_BIT_LENGTH: usize = 2048;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Parameters {
@@ -82,8 +84,7 @@ pub struct PartyPrivate {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeyGenBroadcastMessage1 {
     pub e: EncryptionKey,
-    pub dlog_statement_base_h1: DLogStatement,
-    pub dlog_statement_base_h2: DLogStatement,
+    pub dlog_statement: DLogStatement,
     pub com: BigInt,
     pub correct_key_proof: NICorrectKeyProof,
     pub composite_dlog_proof_base_h1: CompositeDLogProof,
@@ -251,8 +252,7 @@ impl Keys {
         );
         let bcm1 = KeyGenBroadcastMessage1 {
             e: self.ek.clone(),
-            dlog_statement_base_h1,
-            dlog_statement_base_h2,
+            dlog_statement: dlog_statement_base_h1,
             com,
             correct_key_proof,
             composite_dlog_proof_base_h1,
@@ -278,6 +278,11 @@ impl Keys {
         // test paillier correct key, h1,h2 correct generation and test decommitments
         let correct_key_correct_decom_all = (0..bc1_vec.len())
             .map(|i| {
+                let dlog_statement_base_h2 = DLogStatement {
+                    N: bc1_vec[i].dlog_statement.N.clone(),
+                    g: bc1_vec[i].dlog_statement.ni.clone(),
+                    ni: bc1_vec[i].dlog_statement.g.clone(),
+                };
                 let test_res = HashCommitment::create_commitment_with_user_defined_randomness(
                     &decom_vec[i].y_i.bytes_compressed_to_big_int(),
                     &decom_vec[i].blind_factor,
@@ -286,13 +291,17 @@ impl Keys {
                         .correct_key_proof
                         .verify(&bc1_vec[i].e, zk_paillier::zkproofs::SALT_STRING)
                         .is_ok()
+                    && bc1_vec[i].e.n.bit_length() >= PAILLIER_MIN_BIT_LENGTH
+                    && bc1_vec[i].e.n.bit_length() <= PAILLIER_MAX_BIT_LENGTH
+                    && bc1_vec[i].dlog_statement.N.bit_length() >= PAILLIER_MIN_BIT_LENGTH
+                    && bc1_vec[i].dlog_statement.N.bit_length() <= PAILLIER_MAX_BIT_LENGTH
                     && bc1_vec[i]
                         .composite_dlog_proof_base_h1
-                        .verify(&bc1_vec[i].dlog_statement_base_h1)
+                        .verify(&bc1_vec[i].dlog_statement)
                         .is_ok()
                     && bc1_vec[i]
                         .composite_dlog_proof_base_h2
-                        .verify(&bc1_vec[i].dlog_statement_base_h2)
+                        .verify(&dlog_statement_base_h2)
                         .is_ok();
                 if test_res == false {
                     bad_actors_vec.push(i);

--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/keygen/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/keygen/rounds.rs
@@ -265,7 +265,7 @@ impl Round4 {
         let h1_h2_n_tilde_vec = self
             .bc_vec
             .iter()
-            .map(|bc1| bc1.dlog_statement_base_h1.clone())
+            .map(|bc1| bc1.dlog_statement.clone())
             .collect::<Vec<DLogStatement>>();
 
         let (head, tail) = self.y_vec.split_at(1);

--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
@@ -80,7 +80,7 @@ impl Round0 {
         let (bc1, decom1) = sign_keys.phase1_broadcast();
 
         let party_ek = self.local_key.paillier_key_vec[usize::from(self.local_key.i - 1)].clone();
-        let m_a = MessageA::a(&sign_keys.k_i, &party_ek);
+        let m_a = MessageA::a(&sign_keys.k_i, &party_ek, &self.local_key.h1_h2_n_tilde_vec);
 
         output.push(Msg {
             sender: self.i,
@@ -149,12 +149,16 @@ impl Round1 {
                 &self.sign_keys.gamma_i,
                 &self.local_key.paillier_key_vec[l_s[ind]],
                 m_a_vec[ind].clone(),
-            );
+                &self.local_key.h1_h2_n_tilde_vec,
+            )
+            .expect("Incorrect Alice's range proof in MtA");
             let (m_b_w, beta_wi, _, _) = MessageB::b(
                 &self.sign_keys.w_i,
                 &self.local_key.paillier_key_vec[l_s[ind]],
                 m_a_vec[ind].clone(),
-            );
+                &self.local_key.h1_h2_n_tilde_vec,
+            )
+            .expect("Incorrect Alice's range proof in MtA");
 
             m_b_gamma_vec.push(m_b_gamma);
             beta_vec.push(beta_gamma);

--- a/src/protocols/multi_party_ecdsa/gg_2020/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/test.rs
@@ -181,7 +181,7 @@ fn keygen_t_n_parties(
         .collect::<Vec<EncryptionKey>>();
     let h1_h2_N_tilde_vec = bc1_vec
         .iter()
-        .map(|bc1| bc1.dlog_statement_base_h1.clone())
+        .map(|bc1| bc1.dlog_statement.clone())
         .collect::<Vec<DLogStatement>>();
     let y_vec = (0..n).map(|i| decom_vec[i].y_i).collect::<Vec<GE>>();
     let mut y_vec_iter = y_vec.iter();
@@ -308,6 +308,12 @@ fn sign(
     let (bc1_vec, decommit_vec1): (Vec<_>, Vec<_>) =
         sign_keys_vec.iter().map(|k| k.phase1_broadcast()).unzip();
 
+    // each signer's dlog statement. in reality, parties prove statements
+    // using only other parties' h1,h2,N_tilde. here we also use own parameters for simplicity
+    let signers_dlog_statements = (0..ttag)
+        .map(|i| dlog_statement_vec[s[i]].clone())
+        .collect::<Vec<DLogStatement>>();
+
     // each party i BROADCASTS encryption of k_i under her Paillier key
     // m_a_vec = [ma_0;ma_1;,...]
     // we assume here that party sends the same encryption to all other parties.
@@ -315,7 +321,7 @@ fn sign(
     let m_a_vec: Vec<_> = sign_keys_vec
         .iter()
         .enumerate()
-        .map(|(i, k)| MessageA::a(&k.k_i, &party_keys_vec[s[i]].ek))
+        .map(|(i, k)| MessageA::a(&k.k_i, &party_keys_vec[s[i]].ek, &signers_dlog_statements))
         .collect();
 
     // #each party i sends responses to m_a_vec she received (one response with input gamma_i and one with w_i)
@@ -344,9 +350,16 @@ fn sign(
                 &sign_keys_vec[ind].gamma_i,
                 &ek_vec[s[i]],
                 m_a_vec[i].0.clone(),
-            );
-            let (m_b_w, beta_wi, _, _) =
-                MessageB::b(&sign_keys_vec[ind].w_i, &ek_vec[s[i]], m_a_vec[i].0.clone());
+                &signers_dlog_statements,
+            )
+            .expect("Alice's range proofs in MtA failed");
+            let (m_b_w, beta_wi, _, _) = MessageB::b(
+                &sign_keys_vec[ind].w_i,
+                &ek_vec[s[i]],
+                m_a_vec[i].0.clone(),
+                &signers_dlog_statements,
+            )
+            .expect("Alice's range proofs in MtA failed");
 
             m_b_gamma_vec.push(m_b_gamma);
             beta_vec.push(beta_gamma);
@@ -742,4 +755,24 @@ fn test_serialize_deserialize() {
     let encoded = serde_json::to_string(&decommit).unwrap();
     let decoded: KeyGenDecommitMessage1 = serde_json::from_str(&encoded).unwrap();
     assert_eq!(decommit.y_i, decoded.y_i);
+}
+#[test]
+fn test_small_paillier() {
+    // parties shouldn't be able to choose small Paillier modulus
+    let mut k = Keys::create(0);
+    // creating 2046-bit Paillier
+    let (ek, dk) = Paillier::keypair_with_modulus_size(2046).keys();
+    k.dk = dk;
+    k.ek = ek;
+    let (commit, decommit) = k.phase1_broadcast_phase3_proof_of_correct_key_proof_of_correct_h1h2();
+    assert!(k
+        .phase1_verify_com_phase3_verify_correct_key_verify_dlog_phase2_distribute(
+            &Parameters {
+                threshold: 0,
+                share_count: 1
+            },
+            &[decommit],
+            &[commit],
+        )
+        .is_err());
 }

--- a/src/protocols/two_party_ecdsa/lindell_2017/party_two.rs
+++ b/src/protocols/two_party_ecdsa/lindell_2017/party_two.rs
@@ -249,8 +249,9 @@ impl Party2Private {
     pub fn to_mta_message_b(&self, ek: &EncryptionKey, ciphertext: &BigInt) -> (MessageB, FE) {
         let message_a = MessageA {
             c: ciphertext.clone(),
+            range_proofs: vec![],
         };
-        let (a, b, _, _) = MessageB::b(&self.x2, &ek, message_a);
+        let (a, b, _, _) = MessageB::b(&self.x2, &ek, message_a, &[]).unwrap();
         (a, b)
     }
 }

--- a/src/utilities/mta/mod.rs
+++ b/src/utilities/mta/mod.rs
@@ -14,7 +14,7 @@
     @license GPL-3.0+ <https://github.com/KZen-networks/multi-party-ecdsa/blob/master/LICENSE>
 */
 
-/// MtA is descrbied in https://eprint.iacr.org/2019/114.pdf section 3
+/// MtA is described in https://eprint.iacr.org/2019/114.pdf section 3
 use curv::arithmetic::traits::Samplable;
 use curv::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
 use curv::elliptic::curves::secp256_k1::{FE, GE};
@@ -23,14 +23,18 @@ use curv::BigInt;
 use paillier::traits::EncryptWithChosenRandomness;
 use paillier::{Add, Decrypt, Mul};
 use paillier::{DecryptionKey, EncryptionKey, Paillier, Randomness, RawCiphertext, RawPlaintext};
+use zk_paillier::zkproofs::DLogStatement;
+
 use serde::{Deserialize, Serialize};
 
 use crate::protocols::multi_party_ecdsa::gg_2018::party_i::PartyPrivate;
+use crate::utilities::mta::range_proofs::AliceProof;
 use crate::Error::{self, InvalidKey};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MessageA {
-    pub c: BigInt, // paillier encryption
+    pub c: BigInt,                     // paillier encryption
+    pub range_proofs: Vec<AliceProof>, // proofs (using other parties' h1,h2,N_tilde) that the plaintext is small
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -41,79 +45,90 @@ pub struct MessageB {
 }
 
 impl MessageA {
-    pub fn a(a: &FE, alice_ek: &EncryptionKey) -> (Self, BigInt) {
+    /// Creates a new `messageA` using Alice's Paillier encryption key and `dlog_statements`
+    /// - other parties' `h1,h2,N_tilde`s for range proofs.
+    /// If range proofs are not needed (one example is identification of aborts where we
+    /// only want to reconstruct a ciphertext), `dlog_statements` can be an empty slice.
+    pub fn a(
+        a: &FE,
+        alice_ek: &EncryptionKey,
+        dlog_statements: &[DLogStatement],
+    ) -> (Self, BigInt) {
         let randomness = BigInt::sample_below(&alice_ek.n);
-        let c_a = Paillier::encrypt_with_chosen_randomness(
-            alice_ek,
-            RawPlaintext::from(a.to_big_int()),
-            &Randomness::from(randomness.clone()),
-        );
-        (
-            Self {
-                c: c_a.0.clone().into_owned(),
-            },
-            randomness,
-        )
+        let m_a = MessageA::a_with_predefined_randomness(a, alice_ek, &randomness, dlog_statements);
+        (m_a, randomness)
     }
 
     pub fn a_with_predefined_randomness(
         a: &FE,
         alice_ek: &EncryptionKey,
         randomness: &BigInt,
+        dlog_statements: &[DLogStatement],
     ) -> Self {
         let c_a = Paillier::encrypt_with_chosen_randomness(
             alice_ek,
             RawPlaintext::from(a.to_big_int()),
             &Randomness::from(randomness.clone()),
-        );
+        )
+        .0
+        .clone()
+        .into_owned();
+        let alice_range_proofs = dlog_statements
+            .into_iter()
+            .map(|dlog_statement| {
+                AliceProof::generate(&a.to_big_int(), &c_a, alice_ek, dlog_statement, &randomness)
+            })
+            .collect::<Vec<AliceProof>>();
 
         Self {
-            c: c_a.0.clone().into_owned(),
+            c: c_a,
+            range_proofs: alice_range_proofs,
         }
     }
 }
 
 impl MessageB {
-    pub fn b(b: &FE, alice_ek: &EncryptionKey, c_a: MessageA) -> (Self, FE, BigInt, BigInt) {
+    pub fn b(
+        b: &FE,
+        alice_ek: &EncryptionKey,
+        m_a: MessageA,
+        dlog_statements: &[DLogStatement],
+    ) -> Result<(Self, FE, BigInt, BigInt), Error> {
         let beta_tag = BigInt::sample_below(&alice_ek.n);
-        let beta_tag_fe: FE = ECScalar::from(&beta_tag);
         let randomness = BigInt::sample_below(&alice_ek.n);
-        let c_beta_tag = Paillier::encrypt_with_chosen_randomness(
+        let (m_b, beta) = MessageB::b_with_predefined_randomness(
+            b,
             alice_ek,
-            RawPlaintext::from(beta_tag.clone()),
-            &Randomness::from(randomness.clone()),
-        );
+            m_a,
+            &randomness,
+            &beta_tag,
+            dlog_statements,
+        )?;
 
-        let b_bn = b.to_big_int();
-        let b_c_a = Paillier::mul(
-            alice_ek,
-            RawCiphertext::from(c_a.c),
-            RawPlaintext::from(b_bn),
-        );
-        let c_b = Paillier::add(alice_ek, b_c_a, c_beta_tag);
-        let beta = FE::zero().sub(&beta_tag_fe.get_element());
-        let dlog_proof_b = DLogProof::prove(b);
-        let dlog_proof_beta_tag = DLogProof::prove(&beta_tag_fe);
-
-        (
-            Self {
-                c: c_b.0.clone().into_owned(),
-                b_proof: dlog_proof_b,
-                beta_tag_proof: dlog_proof_beta_tag,
-            },
-            beta,
-            randomness,
-            beta_tag,
-        )
+        Ok((m_b, beta, randomness, beta_tag))
     }
 
     pub fn b_with_predefined_randomness(
         b: &FE,
         alice_ek: &EncryptionKey,
-        c_a: MessageA,
+        m_a: MessageA,
         randomness: &BigInt,
         beta_tag: &BigInt,
-    ) -> (Self, FE) {
+        dlog_statements: &[DLogStatement],
+    ) -> Result<(Self, FE), Error> {
+        if m_a.range_proofs.len() != dlog_statements.len() {
+            return Err(InvalidKey);
+        }
+        // verify proofs
+        if !m_a
+            .range_proofs
+            .iter()
+            .zip(dlog_statements)
+            .map(|(proof, dlog_statement)| proof.verify(&m_a.c, alice_ek, dlog_statement))
+            .all(|x| x)
+        {
+            return Err(InvalidKey);
+        };
         let beta_tag_fe: FE = ECScalar::from(beta_tag);
         let c_beta_tag = Paillier::encrypt_with_chosen_randomness(
             alice_ek,
@@ -124,7 +139,7 @@ impl MessageB {
         let b_bn = b.to_big_int();
         let b_c_a = Paillier::mul(
             alice_ek,
-            RawCiphertext::from(c_a.c),
+            RawCiphertext::from(m_a.c),
             RawPlaintext::from(b_bn),
         );
         let c_b = Paillier::add(alice_ek, b_c_a, c_beta_tag);
@@ -132,14 +147,14 @@ impl MessageB {
         let dlog_proof_b = DLogProof::prove(b);
         let dlog_proof_beta_tag = DLogProof::prove(&beta_tag_fe);
 
-        (
+        Ok((
             Self {
                 c: c_b.0.clone().into_owned(),
                 b_proof: dlog_proof_b,
                 beta_tag_proof: dlog_proof_beta_tag,
             },
             beta,
-        )
+        ))
     }
 
     pub fn verify_proofs_get_alpha(
@@ -191,5 +206,6 @@ impl MessageB {
     }
 }
 
+pub mod range_proofs;
 #[cfg(test)]
 mod test;

--- a/src/utilities/mta/range_proofs.rs
+++ b/src/utilities/mta/range_proofs.rs
@@ -1,0 +1,718 @@
+#![allow(non_snake_case)]
+
+//! This file is a modified version of ING bank's range proofs implementation:
+//! https://github.com/ing-bank/threshold-signatures/blob/master/src/algorithms/zkp.rs
+//!
+//! Zero knowledge range proofs for MtA protocol are implemented here.
+//! Formal description can be found in Appendix A of https://eprint.iacr.org/2019/114.pdf
+//! There are some deviations from the original specification:
+//! 1) In Bob's proofs `gamma` is sampled from `[0;q^2 * N]` and `tau` from `[0;q^3 * N_tilde]`.
+//! 2) A non-interactive version is implemented, with challenge `e` computed via Fiat-Shamir.
+
+use curv::arithmetic::traits::*;
+use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use curv::cryptographic_primitives::hashing::traits::Hash;
+use curv::elliptic::curves::secp256_k1::{FE, GE};
+use curv::elliptic::curves::traits::{ECPoint, ECScalar};
+use curv::BigInt;
+
+use paillier::{Add, EncryptionKey, Mul, Randomness, RawCiphertext, RawPlaintext};
+use zk_paillier::zkproofs::DLogStatement;
+
+use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
+use zeroize::Zeroize;
+
+/// Represents the first round of the interactive version of the proof
+struct AliceZkpRound1 {
+    alpha: BigInt,
+    beta: BigInt,
+    gamma: BigInt,
+    ro: BigInt,
+    z: BigInt,
+    u: BigInt,
+    w: BigInt,
+}
+
+/// Zeroize Alice's first round
+impl Zeroize for AliceZkpRound1 {
+    fn zeroize(&mut self) {
+        self.alpha.zeroize();
+        self.beta.zeroize();
+        self.gamma.zeroize();
+        self.ro.zeroize();
+        self.z.zeroize();
+        self.u.zeroize();
+        self.w.zeroize();
+    }
+}
+
+/// Zeroize Alice's first round on drop as it contains secret values
+impl Drop for AliceZkpRound1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl AliceZkpRound1 {
+    fn from(
+        alice_ek: &EncryptionKey,
+        dlog_statement: &DLogStatement,
+        a: &BigInt,
+        q: &BigInt,
+    ) -> Self {
+        let h1 = &dlog_statement.g;
+        let h2 = &dlog_statement.ni;
+        let N_tilde = &dlog_statement.N;
+        let alpha = BigInt::sample_below(&q.pow(3));
+        let beta = BigInt::from_paillier_key(alice_ek);
+        let gamma = BigInt::sample_below(&(q.pow(3) * N_tilde));
+        let ro = BigInt::sample_below(&(q * N_tilde));
+        let z = (BigInt::mod_pow(h1, &a, N_tilde) * BigInt::mod_pow(h2, &ro, N_tilde)) % N_tilde;
+        let u = ((alpha.borrow() * &alice_ek.n + 1)
+            * BigInt::mod_pow(&beta, &alice_ek.n, &alice_ek.nn))
+            % &alice_ek.nn;
+        let w =
+            (BigInt::mod_pow(h1, &alpha, N_tilde) * BigInt::mod_pow(h2, &gamma, N_tilde)) % N_tilde;
+        Self {
+            alpha,
+            beta,
+            gamma,
+            ro,
+            z,
+            u,
+            w,
+        }
+    }
+}
+
+/// Represents the second round of the interactive version of the proof
+struct AliceZkpRound2 {
+    s: BigInt,
+    s1: BigInt,
+    s2: BigInt,
+}
+
+impl AliceZkpRound2 {
+    fn from(
+        alice_ek: &EncryptionKey,
+        round1: &AliceZkpRound1,
+        e: &BigInt,
+        a: &BigInt,
+        r: &BigInt,
+    ) -> Self {
+        Self {
+            s: (BigInt::mod_pow(r, &e, &alice_ek.n) * round1.beta.borrow()) % &alice_ek.n,
+            s1: (e * a) + round1.alpha.borrow(),
+            s2: (e * round1.ro.borrow()) + round1.gamma.borrow(),
+        }
+    }
+}
+
+/// Alice's proof
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AliceProof {
+    z: BigInt,
+    e: BigInt,
+    s: BigInt,
+    s1: BigInt,
+    s2: BigInt,
+}
+
+impl AliceProof {
+    /// verify Alice's proof using the proof and public keys
+    pub fn verify(
+        &self,
+        cipher: &BigInt,
+        alice_ek: &EncryptionKey,
+        dlog_statement: &DLogStatement,
+    ) -> bool {
+        let N = &alice_ek.n;
+        let NN = &alice_ek.nn;
+        let N_tilde = &dlog_statement.N;
+        let h1 = &dlog_statement.g;
+        let h2 = &dlog_statement.ni;
+        let Gen = alice_ek.n.borrow() + 1;
+
+        if self.s1 > FE::q().pow(3) {
+            return false;
+        }
+
+        let z_e_inv = BigInt::mod_inv(&BigInt::mod_pow(&self.z, &self.e, N_tilde), N_tilde);
+        if z_e_inv.is_none() {
+            // z must be invertible, yet the check is done here
+            return false;
+        }
+        let z_e_inv = z_e_inv.unwrap();
+
+        let w = (BigInt::mod_pow(h1, &self.s1, N_tilde)
+            * BigInt::mod_pow(h2, &self.s2, N_tilde)
+            * z_e_inv)
+            % N_tilde;
+
+        let gs1 = (self.s1.borrow() * N + 1) % NN;
+        let cipher_e_inv = BigInt::mod_inv(&BigInt::mod_pow(&cipher, &self.e, NN), NN);
+        if cipher_e_inv.is_none() {
+            return false;
+        }
+        let cipher_e_inv = cipher_e_inv.unwrap();
+
+        let u = (gs1 * BigInt::mod_pow(&self.s, N, NN) * cipher_e_inv) % NN;
+
+        let e = HSha256::create_hash(&[N, &Gen, cipher, &self.z, &u, &w]);
+        if e != self.e {
+            return false;
+        }
+
+        true
+    }
+    /// Create the proof using Alice's Paillier private keys and public ZKP setup.
+    /// Requires randomness used for encrypting Alice's secret a.
+    /// It is assumed that secp256k1 curve is used.
+    pub fn generate(
+        a: &BigInt,
+        cipher: &BigInt,
+        alice_ek: &EncryptionKey,
+        dlog_statement: &DLogStatement,
+        r: &BigInt,
+    ) -> Self {
+        let round1 = AliceZkpRound1::from(alice_ek, dlog_statement, a, &FE::q());
+
+        let Gen = alice_ek.n.borrow() + 1;
+        let e = HSha256::create_hash(&[&alice_ek.n, &Gen, cipher, &round1.z, &round1.u, &round1.w]);
+
+        let round2 = AliceZkpRound2::from(alice_ek, &round1, &e, a, r);
+
+        Self {
+            z: round1.z.clone(),
+            e,
+            s: round2.s,
+            s1: round2.s1,
+            s2: round2.s2,
+        }
+    }
+}
+
+/// Represents first round of the interactive version of the proof
+struct BobZkpRound1 {
+    pub alpha: BigInt,
+    pub beta: BigInt,
+    pub gamma: BigInt,
+    pub ro: BigInt,
+    pub ro_prim: BigInt,
+    pub sigma: BigInt,
+    pub tau: BigInt,
+    pub z: BigInt,
+    pub z_prim: BigInt,
+    pub t: BigInt,
+    pub w: BigInt,
+    pub v: BigInt,
+}
+
+/// Zeroize Bob's first round
+impl Zeroize for BobZkpRound1 {
+    fn zeroize(&mut self) {
+        self.alpha.zeroize();
+        self.beta.zeroize();
+        self.gamma.zeroize();
+        self.ro.zeroize();
+        self.ro_prim.zeroize();
+        self.sigma.zeroize();
+        self.tau.zeroize();
+        self.z.zeroize();
+        self.z_prim.zeroize();
+        self.t.zeroize();
+        self.w.zeroize();
+        self.v.zeroize();
+    }
+}
+
+/// Zeroize Bob's first round on drop as it contains secret values
+impl Drop for BobZkpRound1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl BobZkpRound1 {
+    /// `b` - Bob's secret
+    /// `beta_prim`  - randomly chosen in `MtA` by Bob
+    /// `a_encrypted` - Alice's secret encrypted by Alice
+    fn from(
+        alice_ek: &EncryptionKey,
+        dlog_statement: &DLogStatement,
+        b: &FE,
+        beta_prim: &BigInt,
+        a_encrypted: &BigInt,
+        q: &BigInt,
+    ) -> Self {
+        let h1 = &dlog_statement.g;
+        let h2 = &dlog_statement.ni;
+        let N_tilde = &dlog_statement.N;
+        let b_bn = b.to_big_int();
+
+        let alpha = BigInt::sample_below(&q.pow(3));
+        let beta = BigInt::from_paillier_key(alice_ek);
+        let gamma = BigInt::sample_below(&(q.pow(2) * &alice_ek.n));
+        let ro = BigInt::sample_below(&(q * N_tilde));
+        let ro_prim = BigInt::sample_below(&(q.pow(3) * N_tilde));
+        let sigma = BigInt::sample_below(&(q * N_tilde));
+        let tau = BigInt::sample_below(&(q.pow(3) * N_tilde));
+        let z = (BigInt::mod_pow(h1, &b_bn, N_tilde) * BigInt::mod_pow(h2, &ro, N_tilde)) % N_tilde;
+        let z_prim = (BigInt::mod_pow(h1, &alpha, N_tilde)
+            * BigInt::mod_pow(h2, &ro_prim, N_tilde))
+            % N_tilde;
+        let t = (BigInt::mod_pow(h1, beta_prim, N_tilde) * BigInt::mod_pow(h2, &sigma, N_tilde))
+            % N_tilde;
+        let w =
+            (BigInt::mod_pow(h1, &gamma, N_tilde) * BigInt::mod_pow(h2, &tau, N_tilde)) % N_tilde;
+        let v = (BigInt::mod_pow(a_encrypted, &alpha, &alice_ek.nn)
+            * (gamma.borrow() * &alice_ek.n + 1)
+            * BigInt::mod_pow(&beta, &alice_ek.n, &alice_ek.nn))
+            % &alice_ek.nn;
+        Self {
+            alpha,
+            beta,
+            gamma,
+            ro,
+            ro_prim,
+            sigma,
+            tau,
+            z,
+            z_prim,
+            t,
+            w,
+            v,
+        }
+    }
+}
+
+/// represents second round of the interactive version of the proof
+struct BobZkpRound2 {
+    pub s: BigInt,
+    pub s1: BigInt,
+    pub s2: BigInt,
+    pub t1: BigInt,
+    pub t2: BigInt,
+}
+
+impl BobZkpRound2 {
+    /// `e` - the challenge in interactive ZKP, the hash in non-interactive ZKP
+    /// `b` - Bob's secret
+    /// `beta_prim` - randomly chosen in `MtA` by Bob
+    /// `r` - randomness used by Bob on  Alice's public Paillier key to encrypt `beta_prim` in `MtA`
+    fn from(
+        alice_ek: &EncryptionKey,
+        round1: &BobZkpRound1,
+        e: &BigInt,
+        b: &FE,
+        beta_prim: &BigInt,
+        r: &Randomness,
+    ) -> Self {
+        let b_bn = b.to_big_int();
+        Self {
+            s: (BigInt::mod_pow(r.0.borrow(), e, &alice_ek.n) * round1.beta.borrow()) % &alice_ek.n,
+            s1: (e * b_bn) + round1.alpha.borrow(),
+            s2: (e * round1.ro.borrow()) + round1.ro_prim.borrow(),
+            t1: (e * beta_prim) + round1.gamma.borrow(),
+            t2: (e * round1.sigma.borrow()) + round1.tau.borrow(),
+        }
+    }
+}
+
+/// Additional fields in Bob's proof if MtA is run with check
+pub struct BobCheck {
+    u: GE,
+    X: GE,
+}
+
+/// Bob's regular proof
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct BobProof {
+    t: BigInt,
+    z: BigInt,
+    e: BigInt,
+    s: BigInt,
+    s1: BigInt,
+    s2: BigInt,
+    t1: BigInt,
+    t2: BigInt,
+}
+
+#[allow(clippy::too_many_arguments)]
+impl BobProof {
+    pub fn verify(
+        &self,
+        a_enc: &BigInt,
+        mta_avc_out: &BigInt,
+        alice_ek: &EncryptionKey,
+        dlog_statement: &DLogStatement,
+        check: Option<&BobCheck>,
+    ) -> bool {
+        let N = &alice_ek.n;
+        let NN = &alice_ek.nn;
+        let N_tilde = &dlog_statement.N;
+        let h1 = &dlog_statement.g;
+        let h2 = &dlog_statement.ni;
+
+        if self.s1 > FE::q().pow(3) {
+            return false;
+        }
+
+        let z_e_inv = BigInt::mod_inv(&BigInt::mod_pow(&self.z, &self.e, N_tilde), N_tilde);
+        if z_e_inv.is_none() {
+            // z must be invertible, yet the check is done here
+            return false;
+        }
+        let z_e_inv = z_e_inv.unwrap();
+
+        let z_prim = (BigInt::mod_pow(h1, &self.s1, N_tilde)
+            * BigInt::mod_pow(h2, &self.s2, N_tilde)
+            * z_e_inv)
+            % N_tilde;
+
+        let mta_e_inv = BigInt::mod_inv(&BigInt::mod_pow(mta_avc_out, &self.e, NN), NN);
+        if mta_e_inv.is_none() {
+            // mta_avc_out must be invertible, yet the check is done here
+            return false;
+        }
+        let mta_e_inv = mta_e_inv.unwrap();
+
+        let v = (BigInt::mod_pow(a_enc, &self.s1, NN)
+            * BigInt::mod_pow(&self.s, N, NN)
+            * (self.t1.borrow() * N + 1)
+            * mta_e_inv)
+            % NN;
+
+        let t_e_inv = BigInt::mod_inv(&BigInt::mod_pow(&self.t, &self.e, N_tilde), N_tilde);
+        if t_e_inv.is_none() {
+            // t must be invertible, yet the check is done here
+            return false;
+        }
+        let t_e_inv = t_e_inv.unwrap();
+        let w = (BigInt::mod_pow(h1, &self.t1, N_tilde)
+            * BigInt::mod_pow(h2, &self.t2, N_tilde)
+            * t_e_inv)
+            % N_tilde;
+
+        let Gen = alice_ek.n.borrow() + 1;
+        let mut values_to_hash = vec![
+            &alice_ek.n,
+            &Gen,
+            a_enc,
+            mta_avc_out,
+            &self.z,
+            &z_prim,
+            &self.t,
+            &v,
+            &w,
+        ];
+        let e = if check.is_some() {
+            let X_x_coor = check.unwrap().X.x_coor().unwrap();
+            values_to_hash.push(&X_x_coor);
+            let X_y_coor = check.unwrap().X.y_coor().unwrap();
+            values_to_hash.push(&X_y_coor);
+            let u_x_coor = check.unwrap().u.x_coor().unwrap();
+            values_to_hash.push(&u_x_coor);
+            let u_y_coor = check.unwrap().u.y_coor().unwrap();
+            values_to_hash.push(&u_y_coor);
+            HSha256::create_hash(&values_to_hash[..])
+        } else {
+            HSha256::create_hash(&values_to_hash[..])
+        };
+
+        if e != self.e {
+            return false;
+        }
+
+        true
+    }
+
+    pub fn generate(
+        a_encrypted: &BigInt,
+        mta_encrypted: &BigInt,
+        b: &FE,
+        beta_prim: &BigInt,
+        alice_ek: &EncryptionKey,
+        dlog_statement: &DLogStatement,
+        r: &Randomness,
+        check: bool,
+    ) -> (BobProof, Option<GE>) {
+        let round1 = BobZkpRound1::from(
+            alice_ek,
+            dlog_statement,
+            b,
+            beta_prim,
+            a_encrypted,
+            &FE::q(),
+        );
+
+        let Gen = alice_ek.n.borrow() + 1;
+        let mut values_to_hash = vec![
+            &alice_ek.n,
+            &Gen,
+            a_encrypted,
+            mta_encrypted,
+            &round1.z,
+            &round1.z_prim,
+            &round1.t,
+            &round1.v,
+            &round1.w,
+        ];
+        let mut check_u = None;
+        let e = if check {
+            let (X, u) = {
+                let ec_gen: GE = ECPoint::generator();
+                let alpha: FE = ECScalar::from(&round1.alpha);
+                (ec_gen * b, ec_gen * alpha)
+            };
+            check_u = Some(u);
+            let X_x_coor = X.x_coor().unwrap();
+            values_to_hash.push(&X_x_coor);
+            let X_y_coor = X.y_coor().unwrap();
+            values_to_hash.push(&X_y_coor);
+            let u_x_coor = u.x_coor().unwrap();
+            values_to_hash.push(&u_x_coor);
+            let u_y_coor = u.y_coor().unwrap();
+            values_to_hash.push(&u_y_coor);
+            HSha256::create_hash(&values_to_hash[..])
+        } else {
+            HSha256::create_hash(&values_to_hash[..])
+        };
+
+        let round2 = BobZkpRound2::from(alice_ek, &round1, &e, b, beta_prim, r);
+
+        (
+            BobProof {
+                t: round1.t.clone(),
+                z: round1.z.clone(),
+                e,
+                s: round2.s,
+                s1: round2.s1,
+                s2: round2.s2,
+                t1: round2.t1,
+                t2: round2.t2,
+            },
+            check_u,
+        )
+    }
+}
+
+/// Bob's extended proof, adds the knowledge of $`B = g^b \in \mathcal{G}`$
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct BobProofExt {
+    proof: BobProof,
+    u: GE,
+}
+
+#[allow(clippy::too_many_arguments)]
+impl BobProofExt {
+    pub fn verify(
+        &self,
+        a_enc: &BigInt,
+        mta_avc_out: &BigInt,
+        alice_ek: &EncryptionKey,
+        dlog_statement: &DLogStatement,
+        X: &GE,
+    ) -> bool {
+        // check basic proof first
+        if !self.proof.verify(
+            a_enc,
+            mta_avc_out,
+            alice_ek,
+            dlog_statement,
+            Some(&BobCheck { u: self.u, X: *X }),
+        ) {
+            return false;
+        }
+
+        // fiddle with EC points
+        let (x1, x2) = {
+            let ec_gen: GE = ECPoint::generator();
+            let s1: FE = ECScalar::from(&self.proof.s1);
+            let e: FE = ECScalar::from(&self.proof.e);
+            (ec_gen * s1, (X * &e) + self.u)
+        };
+
+        if x1 != x2 {
+            return false;
+        }
+
+        true
+    }
+
+    fn generate(
+        a_encrypted: &BigInt,
+        mta_encrypted: &BigInt,
+        b: &FE,
+        beta_prim: &BigInt,
+        alice_ek: &EncryptionKey,
+        dlog_statement: &DLogStatement,
+        r: &Randomness,
+    ) -> BobProofExt {
+        // proving a basic proof (with modified hash)
+        let (bob_proof, u) = BobProof::generate(
+            a_encrypted,
+            mta_encrypted,
+            b,
+            beta_prim,
+            alice_ek,
+            dlog_statement,
+            r,
+            true,
+        );
+
+        BobProofExt {
+            proof: bob_proof,
+            u: u.unwrap(),
+        }
+    }
+}
+
+/// sample random value of an element of a multiplicative group
+pub trait SampleFromMultiplicativeGroup {
+    fn from_modulo(N: &BigInt) -> BigInt;
+    fn from_paillier_key(ek: &EncryptionKey) -> BigInt;
+}
+
+impl SampleFromMultiplicativeGroup for BigInt {
+    fn from_modulo(N: &BigInt) -> BigInt {
+        let One = BigInt::one();
+        loop {
+            let r = Self::sample_below(N);
+            if r.gcd(N) == One {
+                return r;
+            }
+        }
+    }
+
+    fn from_paillier_key(ek: &EncryptionKey) -> BigInt {
+        Self::from_modulo(ek.n.borrow())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use paillier::traits::{Encrypt, EncryptWithChosenRandomness, KeyGeneration};
+    use paillier::{DecryptionKey, Paillier};
+
+    pub(crate) fn generate_init() -> (DLogStatement, EncryptionKey, DecryptionKey) {
+        let (ek_tilde, dk_tilde) = Paillier::keypair().keys();
+        let one = BigInt::one();
+        let phi = (&dk_tilde.p - &one) * (&dk_tilde.q - &one);
+        let h1 = BigInt::sample_below(&ek_tilde.n);
+        let (xhi, _) = loop {
+            let xhi_ = BigInt::sample_below(&phi);
+            match BigInt::mod_inv(&xhi_, &phi) {
+                Some(inv) => break (xhi_, inv),
+                None => continue,
+            }
+        };
+        let h2 = BigInt::mod_pow(&h1, &xhi, &ek_tilde.n);
+
+        let (ek, dk) = Paillier::keypair().keys();
+        let dlog_statement = DLogStatement {
+            g: h1,
+            ni: h2,
+            N: ek_tilde.n,
+        };
+        (dlog_statement, ek, dk)
+    }
+
+    #[test]
+    fn alice_zkp() {
+        let (dlog_statement, ek, _) = generate_init();
+
+        // Alice's secret value
+        let a = FE::new_random().to_big_int();
+        let r = BigInt::from_paillier_key(&ek);
+        let cipher = Paillier::encrypt_with_chosen_randomness(
+            &ek,
+            RawPlaintext::from(a.clone()),
+            &Randomness::from(&r),
+        )
+        .0
+        .clone()
+        .into_owned();
+
+        let alice_proof = AliceProof::generate(&a, &cipher, &ek, &dlog_statement, &r);
+
+        assert!(alice_proof.verify(&cipher, &ek, &dlog_statement));
+    }
+
+    #[test]
+    fn bob_zkp() {
+        let (dlog_statement, ek, _) = generate_init();
+
+        (0..5).for_each(|_| {
+            let alice_public_key = &ek;
+
+            // run MtA protocol with different inputs
+            (0..5).for_each(|_| {
+                // Simulate Alice
+                let a = FE::new_random().to_big_int();
+                let encrypted_a = Paillier::encrypt(alice_public_key, RawPlaintext::from(a))
+                    .0
+                    .clone()
+                    .into_owned();
+
+                // Bob follows MtA
+                let b = FE::new_random();
+                // E(a) * b
+                let b_times_enc_a = Paillier::mul(
+                    alice_public_key,
+                    RawCiphertext::from(encrypted_a.clone()),
+                    RawPlaintext::from(&b.to_big_int()),
+                );
+                let beta_prim = BigInt::sample_below(&alice_public_key.n);
+                let r = Randomness::sample(alice_public_key);
+                let enc_beta_prim = Paillier::encrypt_with_chosen_randomness(
+                    alice_public_key,
+                    RawPlaintext::from(&beta_prim),
+                    &r,
+                );
+
+                let mta_out = Paillier::add(alice_public_key, b_times_enc_a, enc_beta_prim);
+
+                let (bob_proof, _) = BobProof::generate(
+                    &encrypted_a,
+                    &mta_out.0.clone().into_owned(),
+                    &b,
+                    &beta_prim,
+                    alice_public_key,
+                    &dlog_statement,
+                    &r,
+                    false,
+                );
+                assert!(bob_proof.verify(
+                    &encrypted_a,
+                    &mta_out.0.clone().into_owned(),
+                    alice_public_key,
+                    &dlog_statement,
+                    None
+                ));
+
+                // Bob follows MtAwc
+                let ec_gen: GE = ECPoint::generator();
+                let X = ec_gen * b;
+                let bob_proof = BobProofExt::generate(
+                    &encrypted_a,
+                    &mta_out.0.clone().into_owned(),
+                    &b,
+                    &beta_prim,
+                    alice_public_key,
+                    &dlog_statement,
+                    &r,
+                );
+                assert!(bob_proof.verify(
+                    &encrypted_a,
+                    &mta_out.0.clone().into_owned(),
+                    alice_public_key,
+                    &dlog_statement,
+                    &X
+                ));
+            });
+        });
+    }
+}

--- a/src/utilities/mta/range_proofs.rs
+++ b/src/utilities/mta/range_proofs.rs
@@ -24,6 +24,8 @@ use std::borrow::Borrow;
 use zeroize::Zeroize;
 
 /// Represents the first round of the interactive version of the proof
+#[derive(Zeroize)]
+#[zeroize(drop)]
 struct AliceZkpRound1 {
     alpha: BigInt,
     beta: BigInt,
@@ -32,26 +34,6 @@ struct AliceZkpRound1 {
     z: BigInt,
     u: BigInt,
     w: BigInt,
-}
-
-/// Zeroize Alice's first round
-impl Zeroize for AliceZkpRound1 {
-    fn zeroize(&mut self) {
-        self.alpha.zeroize();
-        self.beta.zeroize();
-        self.gamma.zeroize();
-        self.ro.zeroize();
-        self.z.zeroize();
-        self.u.zeroize();
-        self.w.zeroize();
-    }
-}
-
-/// Zeroize Alice's first round on drop as it contains secret values
-impl Drop for AliceZkpRound1 {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
 }
 
 impl AliceZkpRound1 {

--- a/src/utilities/mta/test.rs
+++ b/src/utilities/mta/test.rs
@@ -1,15 +1,15 @@
-use crate::utilities::mta::*;
+use crate::utilities::mta::range_proofs::tests::generate_init;
+use crate::utilities::mta::{MessageA, MessageB};
 use curv::elliptic::curves::secp256_k1::FE;
 use curv::elliptic::curves::traits::ECScalar;
-use paillier::traits::KeyGeneration;
 
 #[test]
 fn test_mta() {
     let alice_input: FE = ECScalar::new_random();
-    let (ek_alice, dk_alice) = Paillier::keypair().keys();
+    let (dlog_statement, ek_alice, dk_alice) = generate_init();
     let bob_input: FE = ECScalar::new_random();
-    let (m_a, _r) = MessageA::a(&alice_input, &ek_alice);
-    let (m_b, beta, _, _) = MessageB::b(&bob_input, &ek_alice, m_a);
+    let (m_a, _) = MessageA::a(&alice_input, &ek_alice, &[dlog_statement.clone()]);
+    let (m_b, beta, _, _) = MessageB::b(&bob_input, &ek_alice, m_a, &[dlog_statement]).unwrap();
     let alpha = m_b
         .verify_proofs_get_alpha(&dk_alice, &alice_input)
         .expect("wrong dlog or m_b");


### PR DESCRIPTION
* feat: range proofs for Bob and Alice in MtA implemented
* fix: added Alice's range proof to MtA messageA
* fix: parties now verify sizes of other parties' public moduli
* test: tests for range proofs and small modulus choice
* fix: when verifying dlog between h2 and h1, parties now construct dlog statement themselves instead of taking it from the prover