### PR TITLE
Deprecate rust crypto to support m1 macs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,12 @@ optional = true
 
 [dev-dependencies]
 criterion = "0.3"
-rust-crypto = "0.2"
+#rust-crypto = "0.2"
+aes-gcm = "0.9.4"
 hex = "0.4"
-rocket = { version = "0.4.2", default-features = false }
-rocket_contrib = "0.4.2"
+rocket = { version = "0.5.0-rc.1" }
+#rocket = { version = "0.5.0-rc.1", default-features = false }
+rocket_contrib = "0.4.10"
 reqwest = { version = "0.9", default-features = false }
 uuid = { version = "0.8", features = ["v4"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,9 @@ optional = true
 
 [dev-dependencies]
 criterion = "0.3"
-#rust-crypto = "0.2"
 aes-gcm = "0.9.4"
 hex = "0.4"
-rocket = { version = "0.5.0-rc.1" }
-#rocket = { version = "0.5.0-rc.1", default-features = false }
-rocket_contrib = "0.4.10"
+rocket = { version = "0.5.0-rc.1", features = ["json"] }
 reqwest = { version = "0.9", default-features = false }
 uuid = { version = "0.8", features = ["v4"] }
 serde_json = "1.0"

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -1,14 +1,7 @@
 use std::{env, iter::repeat, thread, time, time::Duration};
-/*
-use crypto::{
-    aead::{AeadDecryptor, AeadEncryptor},
-    aes::KeySize::KeySize256,
-    aes_gcm::AesGcm,
-};
-*/
+
 use aes_gcm::{Aes256Gcm, Nonce};
 use aes_gcm::aead::{NewAead, Aead};
-
 
 use curv::{
     arithmetic::traits::Converter,

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -84,8 +84,8 @@ pub fn aes_decrypt(key: &[u8], aead_pack: AEAD) -> Vec<u8> {
     let gcm = Aes256Gcm::new(aes_key);
 
     let text_payload = Payload {
-        msg: &aead_pack.ciphertext.as_slice(),
-        aad: &aead_pack.tag.as_slice()
+        msg: aead_pack.ciphertext.as_slice(),
+        aad: aead_pack.tag.as_slice()
     };
 
     let out = gcm.decrypt(nonce, text_payload);

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -54,19 +54,14 @@ pub fn aes_encrypt(key: &[u8], plaintext: &[u8]) -> AEAD {
     let aes_key = aes_gcm::Key::from_slice(key);
     let cipher = Aes256Gcm::new(aes_key);
 
-    let rand_string: String = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(12)
-        .map(char::from)
-        .collect();
-
-    let nonce = Nonce::from_slice(rand_string.as_bytes()); // 12-Bytes; unique per message
+    let nonce_vector: Vec<u8> = repeat(3).take(12).collect();
+    let nonce = Nonce::from_slice(nonce_vector.as_slice());
 
     let out_tag: Vec<u8> = repeat(0).take(16).collect();
 
     let text_payload = Payload {
         msg: plaintext,
-        aad: &out_tag[..]
+        aad: &out_tag.as_slice()
     };
 
     let ciphertext = cipher.encrypt(nonce, text_payload)
@@ -83,19 +78,14 @@ pub fn aes_decrypt(key: &[u8], aead_pack: AEAD) -> Vec<u8> {
 
     let aes_key = aes_gcm::Key::from_slice(key);
 
-    let rand_string: String = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(12)
-        .map(char::from)
-        .collect();
-
-    let nonce = Nonce::from_slice(rand_string.as_bytes()); // 12-Bytes; unique per message
+    let nonce_vector: Vec<u8> = repeat(3).take(12).collect();
+    let nonce = Nonce::from_slice(nonce_vector.as_slice());
 
     let gcm = Aes256Gcm::new(aes_key);
 
     let text_payload = Payload {
-        msg: &aead_pack.ciphertext[..],
-        aad: &aead_pack.tag[..]
+        msg: &aead_pack.ciphertext.as_slice(),
+        aad: &aead_pack.tag.as_slice()
     };
 
     let out = gcm.decrypt(nonce, text_payload);

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -9,8 +9,7 @@ use curv::{
     elliptic::curves::traits::{ECPoint, ECScalar},
     BigInt,
 };
-use rand::distributions::Alphanumeric;
-use rand::{Rng, thread_rng};
+
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
@@ -65,7 +64,7 @@ pub fn aes_encrypt(key: &[u8], plaintext: &[u8]) -> AEAD {
     };
 
     let ciphertext = cipher.encrypt(nonce, text_payload)
-        .expect("encryption failure!"); // NOTE: handle this error to avoid panics!
+        .expect("encryption failure!");
 
     AEAD {
         ciphertext: ciphertext,
@@ -89,7 +88,7 @@ pub fn aes_decrypt(key: &[u8], aead_pack: AEAD) -> Vec<u8> {
     };
 
     let out = gcm.decrypt(nonce, text_payload);
-    out.unwrap_or_default()
+    out.unwrap()
 }
 
 pub fn postb<T>(client: &Client, path: &str, body: T) -> Option<String>

--- a/examples/sm_manager.rs
+++ b/examples/sm_manager.rs
@@ -13,7 +13,7 @@ use common::{Entry, Index, Key, Params, PartySignup};
 
 #[post("/get", format = "json", data = "<request>")]
 fn get(
-    db_mtx: State<RwLock<HashMap<Key, String>>>,
+    db_mtx: &State<RwLock<HashMap<Key, String>>>,
     request: Json<Index>,
 ) -> Json<Result<Entry, ()>> {
     let index: Index = request.0;
@@ -137,7 +137,7 @@ fn main() {
         hm.insert(sign_key, serde_json::to_string(&party_signup_sign).unwrap());
     }
     /////////////////////////////////////////////////////////////////
-    rocket::ignite()
+    rocket::build()
         .mount("/", routes![get, set, signup_keygen, signup_sign])
         .manage(db_mtx)
         .launch();

--- a/examples/sm_manager.rs
+++ b/examples/sm_manager.rs
@@ -1,10 +1,11 @@
 #![feature(proc_macro_hygiene, decl_macro)]
+#[macro_use] extern crate rocket;
 
 use std::collections::HashMap;
 use std::fs;
 use std::sync::RwLock;
 
-use rocket::{post, routes, State};
+use rocket::{post, routes, State, launch, Rocket};
 use rocket::serde::json::Json;
 
 use uuid::Uuid;
@@ -103,7 +104,8 @@ fn signup_sign(db_mtx: &State<RwLock<HashMap<Key, String>>>) -> Json<Result<Part
 
 //refcell, arc
 
-fn main() {
+#[launch]
+fn rocket() -> _ {
     // let mut my_config = Config::development();
     // my_config.set_port(18001);
     let db: HashMap<Key, String> = HashMap::new();
@@ -141,5 +143,4 @@ fn main() {
     rocket::build()
         .mount("/", routes![get, set, signup_keygen, signup_sign])
         .manage(db_mtx)
-        .launch();
 }

--- a/examples/sm_manager.rs
+++ b/examples/sm_manager.rs
@@ -5,7 +5,8 @@ use std::fs;
 use std::sync::RwLock;
 
 use rocket::{post, routes, State};
-use rocket_contrib::json::Json;
+use rocket::serde::json::Json;
+
 use uuid::Uuid;
 
 mod common;
@@ -31,7 +32,7 @@ fn get(
 }
 
 #[post("/set", format = "json", data = "<request>")]
-fn set(db_mtx: State<RwLock<HashMap<Key, String>>>, request: Json<Entry>) -> Json<Result<(), ()>> {
+fn set(db_mtx: &State<RwLock<HashMap<Key, String>>>, request: Json<Entry>) -> Json<Result<(), ()>> {
     let entry: Entry = request.0;
     let mut hm = db_mtx.write().unwrap();
     hm.insert(entry.key.clone(), entry.value.clone());
@@ -39,7 +40,7 @@ fn set(db_mtx: State<RwLock<HashMap<Key, String>>>, request: Json<Entry>) -> Jso
 }
 
 #[post("/signupkeygen", format = "json")]
-fn signup_keygen(db_mtx: State<RwLock<HashMap<Key, String>>>) -> Json<Result<PartySignup, ()>> {
+fn signup_keygen(db_mtx: &State<RwLock<HashMap<Key, String>>>) -> Json<Result<PartySignup, ()>> {
     let data = fs::read_to_string("params.json")
         .expect("Unable to read params, make sure config file is present in the same folder ");
     let params: Params = serde_json::from_str(&data).unwrap();
@@ -70,7 +71,7 @@ fn signup_keygen(db_mtx: State<RwLock<HashMap<Key, String>>>) -> Json<Result<Par
 }
 
 #[post("/signupsign", format = "json")]
-fn signup_sign(db_mtx: State<RwLock<HashMap<Key, String>>>) -> Json<Result<PartySignup, ()>> {
+fn signup_sign(db_mtx: &State<RwLock<HashMap<Key, String>>>) -> Json<Result<PartySignup, ()>> {
     //read parameters:
     let data = fs::read_to_string("params.json")
         .expect("Unable to read params, make sure config file is present in the same folder ");

--- a/examples/sm_manager.rs
+++ b/examples/sm_manager.rs
@@ -1,11 +1,10 @@
 #![feature(proc_macro_hygiene, decl_macro)]
-#[macro_use] extern crate rocket;
 
 use std::collections::HashMap;
 use std::fs;
 use std::sync::RwLock;
 
-use rocket::{post, routes, State, launch, Rocket};
+use rocket::{post, routes, State, launch};
 use rocket::serde::json::Json;
 
 use uuid::Uuid;


### PR DESCRIPTION
In the current version (master), Cargo build fails with an error like this, on M1 Mac's (Apple silicon chips):

```
= note: Undefined symbols for architecture arm64:
            “_rust_crypto_util_fixed_time_eq_asm”, referenced from:
                _$LT$crypto..aes_gcm..AesGcm$u20$as$u20$crypto..aead..AeadDecryptor$GT$::decrypt::hb979bb1f732ed3d2 in libcrypto-8dc36bae6f938f30.rlib(crypto-8dc36bae6f938f30.crypto.84e9466e-cgu.9.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

We noticed the [rust-crypto crate is deprecated](https://rustsec.org/advisories/RUSTSEC-2016-0005.html). This removes the dependency to rust-crypto and uses [RustCrypto](https://github.com/RustCrypto) crates instead. Also, there were some errors related to Rocket 0.4.2, for which we upgraded to the latest release (0.5.0-rc.1) based on [this guide](https://rocket.rs/master/guide/upgrading-from-0.4/).  

Thus this branch is now successfully built with arm64 architecture on Mac. It is also tested on Ubuntu 20.04.1 LTS 64bit. 
