### PR TITLE
Improve code quality in gg18 examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ hex = "0.4"
 tokio = { version = "1", default-features = false, features = ["macros"] }
 futures = "0.3"
 rocket = { version = "0.5.0-rc.1", default-features = false, features = ["json"] }
-reqwest = { version = "0.9", default-features = false }
+reqwest = { version = "0.10.1", default-features = false, features = ["native-tls", "json", "blocking"] }
 uuid = { version = "0.8", features = ["v4"] }
 serde_json = "1.0"
 rand = "0.8"
@@ -82,6 +82,10 @@ name = "gg18_keygen_client"
 
 [[example]]
 name = "common"
+crate-type = ["lib"]
+
+[[example]]
+name = "party_client"
 crate-type = ["lib"]
 
 [[bench]]

--- a/examples/gg18_keygen_client.rs
+++ b/examples/gg18_keygen_client.rs
@@ -4,25 +4,25 @@
 /// 2: cargo run from PARTIES number of terminals
 use curv::{
     arithmetic::traits::Converter,
-    cryptographic_primitives::{
-        proofs::sigma_dlog::DLogProof, secret_sharing::feldman_vss::VerifiableSS,
-    },
     elliptic::curves::{secp256_k1::Secp256k1, Point, Scalar},
     BigInt,
 };
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2018::party_i::{
-    KeyGenBroadcastMessage1, KeyGenDecommitMessage1, Keys, Parameters,
+    KeyGenDecommitMessage1, Keys, Parameters,
 };
 use paillier::EncryptionKey;
-use reqwest::Client;
-use sha2::Sha256;
 use std::{env, fs, time};
+use curv::elliptic::curves::Curve;
 
 mod common;
 use common::{
-    aes_decrypt, aes_encrypt, broadcast, poll_for_broadcasts, poll_for_p2p, postb, sendp2p, Params,
-    PartySignup, AEAD, AES_KEY_BYTES_LEN,
+    aes_decrypt, aes_encrypt, Params,
+    AEAD, AES_KEY_BYTES_LEN,
 };
+
+mod party_client;
+use party_client::PartyClient;
+use crate::party_client::ClientPurpose;
 
 fn main() {
     if env::args().nth(3).is_some() {
@@ -31,103 +31,73 @@ fn main() {
     if env::args().nth(2).is_none() {
         panic!("too few arguments")
     }
+    let address = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "http://127.0.0.1:8001".to_string());
+
     //read parameters:
     let data = fs::read_to_string("params.json")
         .expect("Unable to read params, make sure config file is present in the same folder ");
     let params: Params = serde_json::from_str(&data).unwrap();
     let PARTIES: u16 = params.parties.parse::<u16>().unwrap();
     let THRESHOLD: u16 = params.threshold.parse::<u16>().unwrap();
-
-    let client = Client::new();
-
     // delay:
     let delay = time::Duration::from_millis(25);
+
+    //Instantiates a party client and performs signup for the given purpose:
+    let client = PartyClient::new(
+        ClientPurpose::Keygen,
+        Secp256k1::CURVE_NAME,
+        address,
+        delay,
+        params
+    );
+
     let params = Parameters {
         threshold: THRESHOLD,
         share_count: PARTIES,
     };
 
-    //signup:
-    let (party_num_int, uuid) = match signup(&client).unwrap() {
-        PartySignup { number, uuid } => (number, uuid),
-    };
-    println!("number: {:?}, uuid: {:?}", party_num_int, uuid);
+    let party_num_int = client.party_number;
 
     let party_keys = Keys::create(party_num_int);
     let (bc_i, decom_i) = party_keys.phase1_broadcast_phase3_proof_of_correct_key();
 
     // send commitment to ephemeral public keys, get round 1 commitments of other parties
-    assert!(broadcast(
-        &client,
-        party_num_int,
-        "round1",
-        serde_json::to_string(&bc_i).unwrap(),
-        uuid.clone()
-    )
-    .is_ok());
-    let round1_ans_vec = poll_for_broadcasts(
-        &client,
-        party_num_int,
+    let bc1_vec = client.exchange_data(
         PARTIES,
-        delay,
         "round1",
-        uuid.clone(),
+        bc_i
     );
-
-    let mut bc1_vec = round1_ans_vec
-        .iter()
-        .map(|m| serde_json::from_str::<KeyGenBroadcastMessage1>(m).unwrap())
-        .collect::<Vec<_>>();
-
-    bc1_vec.insert(party_num_int as usize - 1, bc_i);
 
     // send ephemeral public keys and check commitments correctness
-    assert!(broadcast(
-        &client,
-        party_num_int,
-        "round2",
-        serde_json::to_string(&decom_i).unwrap(),
-        uuid.clone()
-    )
-    .is_ok());
-    let round2_ans_vec = poll_for_broadcasts(
-        &client,
-        party_num_int,
-        PARTIES,
-        delay,
-        "round2",
-        uuid.clone(),
-    );
+    let decommit_vector: Vec<KeyGenDecommitMessage1> = client.exchange_data(PARTIES, "round2", decom_i);
 
-    let mut j = 0;
-    let mut point_vec: Vec<Point<Secp256k1>> = Vec::new();
-    let mut decom_vec: Vec<KeyGenDecommitMessage1> = Vec::new();
+    let point_vec: Vec<Point<Secp256k1>> = decommit_vector
+        .iter()
+        .map(|x| x.clone().y_i)
+        .collect();
+
     let mut enc_keys: Vec<Vec<u8>> = Vec::new();
     for i in 1..=PARTIES {
-        if i == party_num_int {
-            point_vec.push(decom_i.y_i.clone());
-            decom_vec.push(decom_i.clone());
-        } else {
-            let decom_j: KeyGenDecommitMessage1 = serde_json::from_str(&round2_ans_vec[j]).unwrap();
-            point_vec.push(decom_j.y_i.clone());
-            decom_vec.push(decom_j.clone());
-            let key_bn: BigInt = (decom_j.y_i.clone() * party_keys.u_i.clone())
+        if i != party_num_int {
+            let decommit_j: KeyGenDecommitMessage1 = decommit_vector[(i-1) as usize].clone();
+            let key_bn: BigInt = (decommit_j.y_i.clone() * party_keys.u_i.clone())
                 .x_coord()
                 .unwrap();
             let key_bytes = BigInt::to_bytes(&key_bn);
             let mut template: Vec<u8> = vec![0u8; AES_KEY_BYTES_LEN - key_bytes.len()];
             template.extend_from_slice(&key_bytes[..]);
             enc_keys.push(template);
-            j += 1;
         }
     }
 
     let (head, tail) = point_vec.split_at(1);
-    let y_sum = tail.iter().fold(head[0].clone(), |acc, x| acc + x);
+    let public_key = tail.iter().fold(head[0].clone(), |acc, x| acc + x);
 
     let (vss_scheme, secret_shares, _index) = party_keys
         .phase1_verify_com_phase3_verify_correct_key_phase2_distribute(
-            &params, &decom_vec, &bc1_vec,
+            &params, &decommit_vector, &bc1_vec,
         )
         .expect("invalid key");
 
@@ -140,26 +110,19 @@ fn main() {
             let key_i = &enc_keys[j];
             let plaintext = BigInt::to_bytes(&secret_shares[k].to_bigint());
             let aead_pack_i = aes_encrypt(key_i, &plaintext);
-            assert!(sendp2p(
-                &client,
-                party_num_int,
+            assert!(client.sendp2p(
                 i,
                 "round3",
                 serde_json::to_string(&aead_pack_i).unwrap(),
-                uuid.clone()
             )
             .is_ok());
             j += 1;
         }
     }
 
-    let round3_ans_vec = poll_for_p2p(
-        &client,
-        party_num_int,
+    let round3_ans_vec = client.poll_for_p2p(
         PARTIES,
-        delay,
         "round3",
-        uuid.clone(),
     );
 
     let mut j = 0;
@@ -179,36 +142,12 @@ fn main() {
         }
     }
 
-    // round 4: send vss commitments
-    assert!(broadcast(
-        &client,
-        party_num_int,
-        "round4",
-        serde_json::to_string(&vss_scheme).unwrap(),
-        uuid.clone()
-    )
-    .is_ok());
-    let round4_ans_vec = poll_for_broadcasts(
-        &client,
-        party_num_int,
+    // round 4: send vss commitments and collect them
+    let vss_scheme_vec = client.exchange_data(
         PARTIES,
-        delay,
         "round4",
-        uuid.clone(),
+        vss_scheme
     );
-
-    let mut j = 0;
-    let mut vss_scheme_vec: Vec<VerifiableSS<Secp256k1>> = Vec::new();
-    for i in 1..=PARTIES {
-        if i == party_num_int {
-            vss_scheme_vec.push(vss_scheme.clone());
-        } else {
-            let vss_scheme_j: VerifiableSS<Secp256k1> =
-                serde_json::from_str(&round4_ans_vec[j]).unwrap();
-            vss_scheme_vec.push(vss_scheme_j);
-            j += 1;
-        }
-    }
 
     let (shared_keys, dlog_proof) = party_keys
         .phase2_verify_vss_construct_keypair_phase3_pok_dlog(
@@ -220,30 +159,13 @@ fn main() {
         )
         .expect("invalid vss");
 
-    // round 5: send dlog proof
-    assert!(broadcast(
-        &client,
-        party_num_int,
+    // round 5: send dlog proof and collect them
+    let dlog_proof_vec = client.exchange_data(
+        PARTIES,
         "round5",
-        serde_json::to_string(&dlog_proof).unwrap(),
-        uuid.clone()
-    )
-    .is_ok());
-    let round5_ans_vec =
-        poll_for_broadcasts(&client, party_num_int, PARTIES, delay, "round5", uuid);
+        dlog_proof
+    );
 
-    let mut j = 0;
-    let mut dlog_proof_vec: Vec<DLogProof<Secp256k1, Sha256>> = Vec::new();
-    for i in 1..=PARTIES {
-        if i == party_num_int {
-            dlog_proof_vec.push(dlog_proof.clone());
-        } else {
-            let dlog_proof_j: DLogProof<Secp256k1, Sha256> =
-                serde_json::from_str(&round5_ans_vec[j]).unwrap();
-            dlog_proof_vec.push(dlog_proof_j);
-            j += 1;
-        }
-    }
     Keys::verify_dlog_proofs(&params, &dlog_proof_vec, &point_vec).expect("bad dlog proof");
 
     //save key to file:
@@ -257,15 +179,8 @@ fn main() {
         party_num_int,
         vss_scheme_vec,
         paillier_key_vec,
-        y_sum,
+        public_key,
     ))
     .unwrap();
     fs::write(env::args().nth(2).unwrap(), keygen_json).expect("Unable to save !");
-}
-
-pub fn signup(client: &Client) -> Result<PartySignup, ()> {
-    let key = "signup-keygen".to_string();
-
-    let res_body = postb(client, "signupkeygen", key).unwrap();
-    serde_json::from_str(&res_body).unwrap()
 }

--- a/examples/party_client.rs
+++ b/examples/party_client.rs
@@ -1,0 +1,224 @@
+/*
+    This file contains implementation of a client for each party in MPC applications
+    Copyright 2022
+    Developed by:
+        HRezaei (https://github.com/HRezaei)
+*/
+use std::{thread, time};
+use std::time::Duration;
+use reqwest::blocking::Client;
+
+use crate::common::{Index, Params, PartySignup, Entry};
+
+#[derive(Clone)]
+pub struct PartyClient {
+    client: Client,
+    address: String,
+    uuid: String,
+    delay: Duration,
+    pub party_number: u16,
+}
+
+pub enum ClientPurpose {
+    Keygen,
+    Sign
+}
+
+impl ClientPurpose {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ClientPurpose::Keygen => "keygen",
+            ClientPurpose::Sign => "sign"
+        }
+    }
+}
+
+impl PartyClient {
+    pub fn new(purpose: ClientPurpose, curve_name: &str, address: String, delay: Duration, tn_params: Params) -> Self {
+
+        let mut instance = Self {
+            client: Client::new(),
+            address,
+            delay,
+            uuid: "".to_string(),
+            party_number: 0
+        };
+
+        //Purpose is set to segregate the sessions on the manager
+        let signup_path = "signup".to_owned() + &purpose.as_str();
+        let (party_num_int, uuid) = match instance.signup(&signup_path, &tn_params, curve_name).unwrap() {
+            PartySignup { number, uuid } => (number, uuid),
+        };
+
+        println!("number: {:?}, uuid: {:?}, curve: {:?}", party_num_int, uuid, curve_name);
+
+        instance.uuid = uuid;
+        instance.party_number = party_num_int;
+
+        instance
+    }
+
+    pub fn signup(&self, path:&str, params: &Params, curve_name: &str) -> Result<PartySignup, ()> {
+        let res_body = self.post_request(path, (params, curve_name)).unwrap();
+        serde_json::from_str(&res_body).unwrap()
+    }
+
+    pub fn post_request<T>(&self, path: &str, body: T) -> Option<String>
+        where
+            T: serde::ser::Serialize,
+    {
+        let address = self.address.clone();
+        let retries = 3;
+        let retry_delay = time::Duration::from_millis(250);
+        for _i in 1..retries {
+            let url = format!("{}/{}", address, path);
+            let res = self.client.post(&url).json(&body).send();
+
+            if let Ok(res) = res {
+                return Some(res.text().unwrap());
+            }
+            thread::sleep(retry_delay);
+        }
+        None
+    }
+
+    pub fn broadcast(
+        &self,
+        round: &str,
+        data: String,
+    ) -> Result<(), ()> {
+        let party_num: u16 = self.party_number;
+        let sender_uuid: String = self.uuid.clone();
+        let key = format!("{}-{}-{}", party_num, round, sender_uuid);
+        let entry = Entry {
+            key: key.clone(),
+            value: data,
+        };
+        let res_body = self.post_request("set", entry).unwrap();
+        serde_json::from_str(&res_body).unwrap()
+    }
+
+    pub fn sendp2p(
+        &self,
+        party_to: u16,
+        round: &str,
+        data: String,
+    ) -> Result<(), ()> {
+        let party_from: u16 = self.party_number;
+        let sender_uuid: String = self.uuid.clone();
+
+        let key = format!("{}-{}-{}-{}", party_from, party_to, round, sender_uuid);
+
+        let entry = Entry {
+            key: key.clone(),
+            value: data,
+        };
+
+        let res_body = self.post_request("set", entry).unwrap();
+        serde_json::from_str(&res_body).unwrap()
+    }
+
+    pub fn poll_for_broadcasts(
+        &self,
+        n: u16,
+        round: &str,
+    ) -> Vec<String> {
+        let party_num: u16 = self.party_number;
+        let sender_uuid: String = self.uuid.clone();
+
+        let mut ans_vec = Vec::new();
+        for i in 1..=n {
+            if i != party_num {
+                let key = format!("{}-{}-{}", i, round, sender_uuid);
+                let index = Index { key };
+                loop {
+                    // add delay to allow the server to process request:
+                    thread::sleep(self.delay);
+                    let res_body = self.post_request("get", index.clone()).unwrap();
+                    let answer: Result<Entry, ()> = serde_json::from_str(&res_body).unwrap();
+                    if let Ok(answer) = answer {
+                        ans_vec.push(answer.value);
+                        println!("[{:?}] party {:?} => party {:?}", round, i, party_num);
+                        break;
+                    }
+                }
+            }
+        }
+        ans_vec
+    }
+
+    pub fn poll_for_p2p(
+        &self,
+        n: u16,
+        round: &str,
+    ) -> Vec<String> {
+        let party_num: u16 = self.party_number;
+        let sender_uuid: String = self.uuid.clone();
+
+        let mut ans_vec = Vec::new();
+        for i in 1..=n {
+            if i != party_num {
+                let key = format!("{}-{}-{}-{}", i, party_num, round, sender_uuid);
+                let index = Index { key };
+                loop {
+                    // add delay to allow the server to process request:
+                    thread::sleep(self.delay);
+                    let res_body = self.post_request("get", index.clone()).unwrap();
+                    let answer: Result<Entry, ()> = serde_json::from_str(&res_body).unwrap();
+                    if let Ok(answer) = answer {
+                        ans_vec.push(answer.value);
+                        println!("[{:?}] party {:?} => party {:?}", round, i, party_num);
+                        break;
+                    }
+                }
+            }
+        }
+        ans_vec
+    }
+
+    pub fn exchange_data<T>(&self, parties_count:u16, round: &str, data:T) -> Vec<T>
+        where
+            T: Clone + serde::de::DeserializeOwned + serde::Serialize,
+    {
+        let party_num:u16 = self.party_number;
+        assert!(self.broadcast(
+            &round,
+            serde_json::to_string(&data).unwrap(),
+        )
+            .is_ok());
+        let round_ans_vec = self.poll_for_broadcasts(
+            parties_count,
+            &round,
+        );
+
+        let json_answers = &round_ans_vec.clone();
+        let mut answers: Vec<T> = Vec::new();
+        PartyClient::format_vec_from_reads(
+            json_answers,
+            party_num as usize,
+            data,
+            &mut answers
+        );
+
+        answers.clone()
+    }
+
+    fn format_vec_from_reads<'a, T: serde::Deserialize<'a> + Clone>(
+        ans_vec: &'a [String],
+        party_num: usize,
+        value_i: T,
+        new_vec: &'a mut Vec<T>,
+    ) {
+        let mut j = 0;
+        for i in 1..ans_vec.len() + 2 {
+            if i == party_num {
+                new_vec.push(value_i.clone());
+            } else {
+                let value_j: T = serde_json::from_str(&ans_vec[j]).unwrap();
+                new_vec.push(value_j);
+                j += 1;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This is the first try to improve code quality of the gg18 examples a little bit further.

Inspired from [this article](https://towardsdatascience.com/python-clean-code-6-best-practices-to-make-your-python-functions-more-readable-7ea4c6171d60), I'm going to break down the main function in sign and keygen clients into smaller ones. For now, I created a client struct and moved most of the stuff relating to communication between parties into it. 

Hope you accept these changes so we can apply similar changes into tss_cli and make it more readable and easier for maintenance. 