### PR TITLE
Added a check for the length of PDLwSlackProof vector.

### DIFF
--- a/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
@@ -731,8 +731,7 @@ impl LocalSignature {
         let num_of_other_participants = s.len() - 1;
         if pdl_w_slack_proof_vec.len() != num_of_other_participants {
             bad_actors_vec.push(i);
-        }
-        else {
+        } else {
             let proofs_verification = (0..pdl_w_slack_proof_vec.len())
                 .map(|j| {
                     let ind = if j < i { j } else { j + 1 };

--- a/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
@@ -728,37 +728,42 @@ impl LocalSignature {
     ) -> Result<(), ErrorType> {
         let mut bad_actors_vec = Vec::new();
 
-        let proofs_verification = (0..pdl_w_slack_proof_vec.len())
-            .map(|j| {
-                let ind = if j < i { j } else { j + 1 };
-                let pdl_w_slack_statement = PDLwSlackStatement {
-                    ciphertext: k_ciphertext.clone(),
-                    ek: ek.clone(),
-                    Q: R_dash.clone(),
-                    G: R.clone(),
-                    h1: dlog_statement[s[ind]].g.clone(),
-                    h2: dlog_statement[s[ind]].ni.clone(),
-                    N_tilde: dlog_statement[s[ind]].N.clone(),
-                };
-                let ver_res = pdl_w_slack_proof_vec[j].verify(&pdl_w_slack_statement);
-                if ver_res.is_err() {
-                    bad_actors_vec.push(i);
-                    false
-                } else {
-                    true
-                }
-            })
-            .all(|x| x);
+        let num_of_other_participants = s.len() - 1;
+        if pdl_w_slack_proof_vec.len() != num_of_other_participants {
+            bad_actors_vec.push(i);
+        }
+        else {
+            let proofs_verification = (0..pdl_w_slack_proof_vec.len())
+                .map(|j| {
+                    let ind = if j < i { j } else { j + 1 };
+                    let pdl_w_slack_statement = PDLwSlackStatement {
+                        ciphertext: k_ciphertext.clone(),
+                        ek: ek.clone(),
+                        Q: R_dash.clone(),
+                        G: R.clone(),
+                        h1: dlog_statement[s[ind]].g.clone(),
+                        h2: dlog_statement[s[ind]].ni.clone(),
+                        N_tilde: dlog_statement[s[ind]].N.clone(),
+                    };
+                    let ver_res = pdl_w_slack_proof_vec[j].verify(&pdl_w_slack_statement);
+                    if ver_res.is_err() {
+                        bad_actors_vec.push(i);
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .all(|x| x);
+            if proofs_verification {
+                return Ok(());
+            }
+        }
 
         let err_type = ErrorType {
-            error_type: "bad gamma_i decommit".to_string(),
+            error_type: "Bad PDLwSlack proof".to_string(),
             bad_actors: bad_actors_vec,
         };
-        if proofs_verification {
-            Ok(())
-        } else {
-            Err(err_type)
-        }
+        Err(err_type)
     }
 
     pub fn phase5_check_R_dash_sum(R_dash_vec: &[Point<Secp256k1>]) -> Result<(), Error> {

--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
@@ -498,14 +498,10 @@ impl Round5 {
     where
         O: Push<Msg<(SI, HEGProof)>>,
     {
-        let num_of_other_participants = self.s_l.len() - 1;
         let (r_dash_vec, pdl_proof_mat_inc_me): (Vec<_>, Vec<_>) = input
             .into_vec_including_me((RDash(self.R_dash), self.phase5_proofs_vec))
             .into_iter()
-            .map(|(r_dash, pdl_proof)| {
-                assert_eq!(pdl_proof.len(), num_of_other_participants);
-                (r_dash.0, pdl_proof)
-            })
+            .map(|(r_dash, pdl_proof)| (r_dash.0, pdl_proof))
             .unzip();
 
         let l_s: Vec<_> = self

--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
@@ -498,10 +498,14 @@ impl Round5 {
     where
         O: Push<Msg<(SI, HEGProof)>>,
     {
+        let num_of_other_participants = self.s_l.len() - 1;
         let (r_dash_vec, pdl_proof_mat_inc_me): (Vec<_>, Vec<_>) = input
             .into_vec_including_me((RDash(self.R_dash), self.phase5_proofs_vec))
             .into_iter()
-            .map(|(r_dash, pdl_proof)| (r_dash.0, pdl_proof))
+            .map(|(r_dash, pdl_proof)| {
+                assert_eq!(pdl_proof.len(), num_of_other_participants);
+                (r_dash.0, pdl_proof)
+            })
             .unzip();
 
         let l_s: Vec<_> = self


### PR DESCRIPTION
Hey, @MatanHamilis! Sorry for taking so long to write two lines of code. Quite frankly, I just forgot about this. I think there are no more places in the code where the length check needs to be performed (in keygen round 3 and sign round 2, P2P container is used where parties need to send a list of messages).
PS. I only added an `assert_eq`, without returning the vector of misbehaving parties. When implementing identifiable aborts, this should be changed. Or I can do it now.