### PR TITLE
Pedersen proof needs a check on the "com" field

### DIFF
--- a/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
@@ -628,7 +628,7 @@ impl SignKeys {
         let l = Scalar::<Secp256k1>::random();
         let h_l = Point::<Secp256k1>::base_point2() * &l;
         let T = g_sigma_i + h_l;
-        let T_zk_proof = PedersenProof::<Secp256k1, Sha256>::prove(&(sigma_i + sigma_i), &l);
+        let T_zk_proof = PedersenProof::<Secp256k1, Sha256>::prove(sigma_i, &l);
 
         (T, l, T_zk_proof)
     }

--- a/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs
@@ -628,7 +628,7 @@ impl SignKeys {
         let l = Scalar::<Secp256k1>::random();
         let h_l = Point::<Secp256k1>::base_point2() * &l;
         let T = g_sigma_i + h_l;
-        let T_zk_proof = PedersenProof::<Secp256k1, Sha256>::prove(sigma_i, &l);
+        let T_zk_proof = PedersenProof::<Secp256k1, Sha256>::prove(&(sigma_i + sigma_i), &l);
 
         (T, l, T_zk_proof)
     }

--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
@@ -341,7 +341,7 @@ impl Round3 {
             .unzip3();
 
         for i in 0..t_vec.len() {
-            assert_eq!(t_vec[i],t_proof_vec[i].com);
+            assert_eq!(t_vec[i], t_proof_vec[i].com);
         }
 
         let delta_inv = SignKeys::phase3_reconstruct_delta(&delta_vec);

--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
@@ -340,6 +340,10 @@ impl Round3 {
             .map(|(delta_i, t_i, t_i_proof)| (delta_i.0, t_i.0, t_i_proof.0))
             .unzip3();
 
+        for i in 0..t_vec.len() {
+            assert_eq!(t_vec[i],t_proof_vec[i].com);
+        }
+
         let delta_inv = SignKeys::phase3_reconstruct_delta(&delta_vec);
         let ttag = self.s_l.len();
         for proof in t_proof_vec.iter().take(ttag) {

--- a/src/protocols/multi_party_ecdsa/gg_2020/test.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/test.rs
@@ -481,6 +481,7 @@ fn sign(
     }
     // verify T_proof_vec
     for i in 0..ttag {
+        assert_eq!(T_vec[i], T_proof_vec[i].com.clone());
         PedersenProof::verify(&T_proof_vec[i]).expect("error T proof");
     }
     // de-commit to g^gamma_i from phase1, test comm correctness, and that it is the same value used in MtA.


### PR DESCRIPTION
In GG20 Phase 4, verification of the T_i pedersen proof doesn't have a check against the actual T_i values used.

currently, if you modify https://github.com/ZenGo-X/multi-party-ecdsa/blob/a59b657dc4850a5219e5165424bf85b6b9fb9067/src/protocols/multi_party_ecdsa/gg_2020/party_i.rs#L631 to become 
`let T_zk_proof = PedersenProof::<Secp256k1, Sha256>::prove(&(sigma_i + sigma_i), &l);`, it still passes all the tests.