### PR TITLE
replace all expect() with Errortype 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@
 
 pub mod protocols;
 pub mod utilities;
+use std::fmt;
+
 #[derive(Copy, PartialEq, Eq, Clone, Debug)]
 pub enum Error {
     InvalidKey,
@@ -28,4 +30,18 @@ pub enum Error {
     InvalidSig,
     Phase5BadSum,
     Phase6Error,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Error::*;
+        match *self {
+            InvalidKey => write!(f, "InvalidKey"),
+            InvalidSS => write!(f, "InvalidSS"),
+            InvalidCom => write!(f, "InvalidCom"),
+            InvalidSig => write!(f, "InvalidSig"),
+            Phase5BadSum => write!(f, "Phase5BadSum"),
+            Phase6Error => write!(f, "Phase6Error"),
+        }
+    }
 }

--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
@@ -147,20 +147,34 @@ impl Round1 {
         let i = usize::from(self.i - 1);
         for j in 0..ttag - 1 {
             let ind = if j < i { j } else { j + 1 };
+
             let (m_b_gamma, beta_gamma, _beta_randomness, _beta_tag) = MessageB::b(
                 &self.sign_keys.gamma_i,
                 &self.local_key.paillier_key_vec[l_s[ind]],
                 m_a_vec[ind].clone(),
                 &self.local_key.h1_h2_n_tilde_vec,
             )
-            .expect("Incorrect Alice's range proof in MtA");
+            .map_err(|e| {
+                Error::Round1(ErrorType {
+                    error_type: e.to_string(),
+                    bad_actors: vec![],
+                    data: vec![],
+                })
+            })?;
+
             let (m_b_w, beta_wi, _, _) = MessageB::b(
                 &self.sign_keys.w_i,
                 &self.local_key.paillier_key_vec[l_s[ind]],
                 m_a_vec[ind].clone(),
                 &self.local_key.h1_h2_n_tilde_vec,
             )
-            .expect("Incorrect Alice's range proof in MtA");
+            .map_err(|e| {
+                Error::Round1(ErrorType {
+                    error_type: e.to_string(),
+                    bad_actors: vec![],
+                    data: vec![],
+                })
+            })?;
 
             m_b_gamma_vec.push(m_b_gamma);
             beta_vec.push(beta_gamma);
@@ -251,11 +265,23 @@ impl Round2 {
 
             let alpha_ij_gamma = m_b
                 .verify_proofs_get_alpha(&self.local_key.paillier_dk, &self.sign_keys.k_i)
-                .expect("wrong dlog or m_b");
+                .map_err(|e| {
+                    Error::Round3(ErrorType {
+                        error_type: e.to_string(),
+                        bad_actors: vec![],
+                        data: vec![],
+                    })
+                })?;
             let m_b = m_b_w_s[j].clone();
             let alpha_ij_wi = m_b
                 .verify_proofs_get_alpha(&self.local_key.paillier_dk, &self.sign_keys.k_i)
-                .expect("wrong dlog or m_b");
+                .map_err(|e| {
+                    Error::Round3(ErrorType {
+                        error_type: e.to_string(),
+                        bad_actors: vec![],
+                        data: vec![],
+                    })
+                })?;
             assert_eq!(m_b.b_proof.pk, g_w_vec[ind]); //TODO: return error
 
             alpha_vec.push(alpha_ij_gamma.0);
@@ -347,7 +373,13 @@ impl Round3 {
         let delta_inv = SignKeys::phase3_reconstruct_delta(&delta_vec);
         let ttag = self.s_l.len();
         for proof in t_proof_vec.iter().take(ttag) {
-            PedersenProof::verify(proof).expect("error T proof");
+            PedersenProof::verify(proof).map_err(|e| {
+                Error::Round3(ErrorType {
+                    error_type: e.to_string(),
+                    bad_actors: vec![],
+                    data: vec![],
+                })
+            })?;
         }
 
         output.push(Msg {
@@ -420,7 +452,8 @@ impl Round4 {
             &self.bc_vec,
             usize::from(self.i - 1),
         )
-        .expect(""); //TODO: propagate the error
+        .map_err(|e| Error::Round5(e))?;
+
         let R_dash = &R * &self.sign_keys.k_i;
 
         // each party sends first message to all other parties
@@ -526,9 +559,15 @@ impl Round5 {
                 &l_s,
                 i,
             )
-            .expect("phase5 verify pdl error");
+            .map_err(|e| Error::Round5(e))?;
         }
-        LocalSignature::phase5_check_R_dash_sum(&r_dash_vec).expect("R_dash error");
+        LocalSignature::phase5_check_R_dash_sum(&r_dash_vec).map_err(|e| {
+            Error::Round5(ErrorType {
+                error_type: e.to_string(),
+                bad_actors: vec![],
+                data: vec![],
+            })
+        })?;
 
         let (S_i, homo_elgamal_proof) = LocalSignature::phase6_compute_S_i_and_proof_of_consistency(
             &self.R,

--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
@@ -158,7 +158,6 @@ impl Round1 {
                 Error::Round1(ErrorType {
                     error_type: e.to_string(),
                     bad_actors: vec![],
-                    data: vec![],
                 })
             })?;
 
@@ -172,7 +171,6 @@ impl Round1 {
                 Error::Round1(ErrorType {
                     error_type: e.to_string(),
                     bad_actors: vec![],
-                    data: vec![],
                 })
             })?;
 
@@ -269,7 +267,6 @@ impl Round2 {
                     Error::Round3(ErrorType {
                         error_type: e.to_string(),
                         bad_actors: vec![],
-                        data: vec![],
                     })
                 })?;
             let m_b = m_b_w_s[j].clone();
@@ -279,7 +276,6 @@ impl Round2 {
                     Error::Round3(ErrorType {
                         error_type: e.to_string(),
                         bad_actors: vec![],
-                        data: vec![],
                     })
                 })?;
             assert_eq!(m_b.b_proof.pk, g_w_vec[ind]); //TODO: return error
@@ -377,7 +373,6 @@ impl Round3 {
                 Error::Round3(ErrorType {
                     error_type: e.to_string(),
                     bad_actors: vec![],
-                    data: vec![],
                 })
             })?;
         }
@@ -565,7 +560,6 @@ impl Round5 {
             Error::Round5(ErrorType {
                 error_type: e.to_string(),
                 bad_actors: vec![],
-                data: vec![],
             })
         })?;
 


### PR DESCRIPTION
Replace all `.expect()` in code with ErrorType struct for better error handling and avoiding unwanted panic.

cc @drewstone @shekohex