### PR TITLE
backup feature and Ser/Deser for CompletedOfflineStage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ crate-type = ["lib"]
 [features]
 default = ["curv-kzen/rust-gmp-kzen"]
 cclst = ["class_group"]
+backup = []
 
 [dependencies]
 subtle = { version = "2" }
@@ -112,3 +113,4 @@ harness = false
 name = "lindel2017_sign"
 path = "benches/two_party_ecdsa/lindell_2017/sign.rs"
 harness = false
+

--- a/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
+++ b/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs
@@ -612,6 +612,7 @@ impl Round6 {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "backup", derive(Serialize, Deserialize))]
 pub struct CompletedOfflineStage {
     i: u16,
     local_key: LocalKey<Secp256k1>,


### PR DESCRIPTION
As generation off `CompletedOfflineStage` requires presence of all participants - it is logical to have some arbitrary number of them generated right after key generation is complete.
And for DR reasons it should be possible to store all crypto material for cold re-start. 
This PR have feature gated `Serialize` and `Deserialize` derives for `CompletedOfflineStage` to be able to pre-generate and backup them to have truly threshold signing enabled.