### PR TITLE
Fixed client port issues in 'run.sh'

### DIFF
--- a/demo/run.sh
+++ b/demo/run.sh
@@ -21,7 +21,7 @@ echo "keygen part"
 for i in $(seq 1 $n)
 do
     echo "key gen for client $i out of $n"
-    ./target/release/examples/gg18_keygen_client http://127.0.0.1:8001 keys$i.store &
+    ./target/release/examples/gg18_keygen_client http://127.0.0.1:8000 keys$i.store &
     sleep 3
 done
 
@@ -33,7 +33,7 @@ echo "sign"
 for i in $(seq 1 $((t+1)));
 do
     echo "signing for client $i out of $((t+1))"
-    ./target/release/examples/gg18_sign_client http://127.0.0.1:8001 keys$i.store "KZen Networks" &
+    ./target/release/examples/gg18_sign_client http://127.0.0.1:8000 keys$i.store "KZen Networks" &
     sleep 3
 done
 


### PR DESCRIPTION
`thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', examples/gg18_keygen_client.rs:269:55
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
`
This is rust reporting an error when I run the **run.sh** file . I found that the port number in the running parameters of **gg18_keygen_client** and **gg18_sign_client** was different from the port number run by **gg18_sm_manager**, so I changed it to **8000** before  the program executes correctly.